### PR TITLE
Validate XML structure in parse function

### DIFF
--- a/proxy/src/parse.ts
+++ b/proxy/src/parse.ts
@@ -19,7 +19,7 @@ export function parseDocument(
     throw new Error('Failed to parse XML document');
   }
   if (Object.keys(jObj).length !== 2) {
-    throw new Error('Please use one <?xml> element and one <Invoice> or <CreditNote> element at the top level');
+    throw new Error('XML document must contain exactly one XML declaration (<?xml ...?>) and one root element (<Invoice> or <CreditNote>) at the top level');
   }
   if (Object.keys(jObj)[0] !== '?xml') {
     throw new Error('Missing top level ?xml declaration');


### PR DESCRIPTION
Add validation for top-level XML elements in parse function.

This is part of security for determining the sender identifier which will later be checked against the user's JWT token