### PR TITLE
Remove Docker Compose section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ This repo will contain all the code involved in running the Let's Peppol project
 * a [kyc](./kyc/) folder that contains the Know-Your-Customer component (initially only for Belgian VAT numbers)
 * an [app](./app/) folder that contains our web interface
 
+# KYC
+The main challenge of giving free-of-charge access to the Peppol e-invoicing network is authentication of legal entities. For this, we:
+* implemented a KYC component that gives our JWT tokens, that the API proxy from milestone 5a can check and trust
+* used the open source [https://web-eid.eu](https://web-eid.eu) software
+* let the user connect a card reader to their computer, and put their Belgian identity card into it
+* let the user install some desktop software as well as a browser plugin (both open source from [https://web-eid.eu](https://web-eid.eu))
+* with this the user can issue a QES legally binding signature (this only works for Belgian, Estonian, and 4 other countries, this is not yet possible for the Netherlands)
+* We created a legal entity under Belgian law and had a lawyer write a contract that the person signs, stating they are one of the directors of a Belgian comany
+* this legal entity is in the process of getting full access to the Belgian companies registry, so we can check the first and last name that the person claims to be.
+
+[Here is a screencast](https://drive.google.com/file/d/1HHSM9V1_2ez59vlnkL0YO3190X1uOh1j/view) that shows our fully automated business authentication in production.
+
+# Dasboard application
+A public instance of this code will soon be available, please keep an eye on [LetsPeppol.org](https://letspeppol.org).
+
+[Here is a screencast](https://drive.google.com/file/d/1HHSM9V1_2ez59vlnkL0YO3190X1uOh1j/view?usp=drive_link) of how the application can be used to send and receive invoices via Let's Peppol.
+
 # Usage
 ## With Nix
 [FIXME: docs under construction]


### PR DESCRIPTION
There is not currently a docker compose file in the repo root, so better to remove this section?