### PR TITLE
Route Adminer and Grafana through internal Traefik entrypoint

### DIFF
--- a/docker/database/docker-compose.yml
+++ b/docker/database/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.adminer.rule=Host(`${ADMINER_DOMAIN}`)"
-      - "traefik.http.routers.adminer.entrypoints=websecure"
+      - "traefik.http.routers.adminer.entrypoints=internal"
       - "traefik.http.routers.adminer.tls.certresolver=${CERT_RESOLVER}"
       - "traefik.http.services.adminer.loadbalancer.server.port=8080"
 

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -83,7 +83,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.grafana.rule=Host(`${GRAFANA_DOMAIN}`)"
-      - "traefik.http.routers.grafana.entrypoints=websecure"
+      - "traefik.http.routers.grafana.entrypoints=internal"
       - "traefik.http.routers.grafana.tls.certresolver=${CERT_RESOLVER}"
       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
 

--- a/docker/traefik/docker-compose.yml
+++ b/docker/traefik/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
       - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
       - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.internal.address=:8443"
 
       # Let's Encrypt (for public domains)
       - "--certificatesresolvers.letsencrypt.acme.email=letsencrypt@letspeppol.org"
@@ -44,6 +45,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "8443:8443"
 
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
This PR introduces a dedicated Traefik internal entrypoint on port 8443 and updates the Adminer and Grafana routers to use it instead of the public websecure entrypoint on port 443.

### Motivation
Admin and monitoring tools should not be accessed through the public HTTPS entrypoint.
Using a separate internal entrypoint allows access restriction at the network level.

### Changes
* Add new Traefik entrypoint
* Expose port 8443 on the Traefik container
* Move Adminer and Grafana routers from websecure to internal

### Impact
* Adminer and Grafana are no longer available on port 443