### PR TITLE
Fix PostgreSQL backup scheduling and local retention

### DIFF
--- a/docker/database/docker-compose.yml
+++ b/docker/database/docker-compose.yml
@@ -55,18 +55,53 @@ services:
       - /opt/data/db:/opt/data/db
     command: >
       sh -c '
-        mkdir -p "$$DATA_DIR";
-        echo "[backup] starting loop for $${DB_LIST}";
-        while :; do
-          ts=$$(date "+%Y-%m-%dT%H-%M-%S%z");
-          for d in $${DB_LIST}; do
-            echo "[backup] dumping $$d at $$ts";
-            pg_dump -h "$$PGHOST" -U "$$PGUSER" -d "$$d" -F c -Z 6 -f "$$DATA_DIR/$$d-$$ts.dump" || echo "[backup] FAILED $$d";
-          done;
-          # optional: keep 14 days
-          find "$$DATA_DIR" -type f -name "*.dump" -mtime +14 -delete || true;
-          sleep 43200;
-        done
+        set -eu
+        mkdir -p "$$DATA_DIR"
+
+        cat <<'\''EOF'\'' >/etc/crontabs/root
+        SHELL=/bin/sh
+        TZ=Europe/Brussels
+
+        0 0,12 * * * /bin/sh -c '\''
+          set -eu
+
+          ts=$$(date "+%Y-%m-%dT%H-%M-%S%z")
+
+          for d in $$DB_LIST; do
+            echo "[backup] preparing $$d at $$ts"
+
+            # Keep only 1 existing backup before creating the new one.
+            # After the new one succeeds, there will be 2 total.
+            ls -1t "$$DATA_DIR"/$$d-*.dump 2>/dev/null \
+              | tail -n +2 \
+              | xargs -r rm -f --
+
+            tmp="$$DATA_DIR/.$$d-$$ts.dump.tmp"
+            final="$$DATA_DIR/$$d-$$ts.dump"
+
+            echo "[backup] dumping $$d to temp file $$tmp"
+
+            if pg_dump \
+              -h "$$PGHOST" \
+              -U "$$PGUSER" \
+              -d "$$d" \
+              -F c \
+              -Z 6 \
+              -f "$$tmp"
+            then
+              mv "$$tmp" "$$final"
+              echo "[backup] completed $$d -> $$final"
+            else
+              echo "[backup] FAILED $$d"
+              rm -f "$$tmp"
+              exit 1
+            fi
+          done
+        '\''
+        EOF
+
+        echo "[backup] scheduled for 00:00 and 12:00 Europe/Brussels"
+        exec crond -f -l 2
       '
     networks:
       - default


### PR DESCRIPTION
This PR replaces the drifting backup loop with fixed-time scheduling and limits local backup retention.

### Changes
- Replace the drifting sleep-based backup loop with cron-based scheduling at fixed times
- Write dumps to temporary files and only rename them after a successful `pg_dump`
- Limit local backup retention to two backups per database