### PR TITLE
Bugfix/262 ux improvements

### DIFF
--- a/app/backend/src/main/java/org/letspeppol/app/config/DataInitializer.java
+++ b/app/backend/src/main/java/org/letspeppol/app/config/DataInitializer.java
@@ -82,6 +82,7 @@ public class DataInitializer implements CommandLineRunner {
                     new BigDecimal("6.99"),
                     new BigDecimal("14.99"),
                     new BigDecimal("21"),
+                    new BigDecimal("10"),
                     productCategory.id()
             );
             productService.createProduct(peppolId, product);

--- a/app/backend/src/main/java/org/letspeppol/app/controller/DocumentController.java
+++ b/app/backend/src/main/java/org/letspeppol/app/controller/DocumentController.java
@@ -117,6 +117,15 @@ public class DocumentController {
         return documentService.send(peppolId, id, schedule, jwt.getTokenValue());
     }
 
+    @PutMapping("{id}/reschedule")
+    public DocumentDto reschedule(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID id, @RequestParam(required = false) Instant schedule) {
+        if (!JwtUtil.isPeppolActive(jwt)) {
+            throw new PeppolException("Peppol ID is not active");
+        }
+        String peppolId = JwtUtil.getPeppolId(jwt);
+        return documentService.reschedule(peppolId, id, schedule, jwt.getTokenValue());
+    }
+
     @PutMapping("{id}/read")
     public DocumentDto read(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID id) {
         String peppolId = JwtUtil.getPeppolId(jwt);

--- a/app/backend/src/main/java/org/letspeppol/app/dto/ProductDto.java
+++ b/app/backend/src/main/java/org/letspeppol/app/dto/ProductDto.java
@@ -11,5 +11,6 @@ public record ProductDto(
         BigDecimal costPrice,
         BigDecimal salePrice,
         BigDecimal taxPercentage,
+        BigDecimal stockQuantity,
         Long categoryId
 ) {}

--- a/app/backend/src/main/java/org/letspeppol/app/mapper/ProductMapper.java
+++ b/app/backend/src/main/java/org/letspeppol/app/mapper/ProductMapper.java
@@ -15,6 +15,7 @@ public class ProductMapper {
             product.getCostPrice(),
             product.getSalePrice(),
             product.getTaxPercentage(),
+            product.getStockQuantity(),
             product.getCategory() != null ? product.getCategory().getId() : null
         );
     }

--- a/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
+++ b/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
@@ -281,8 +281,24 @@ public class DocumentService {
 //        document = documentRepository.save(document); //Not saving, as we only save the proxy returned result
         backupService.backupFile(document);
         documentBackupCounter.increment(); //TODO : how to correctly use these counters ?
-        document = deliverOnSchedule(document, tokenValue);
+        document = deliver(document, tokenValue);
         documentSendCounter.increment();
+        return DocumentMapper.toDto(document);
+    }
+
+    public DocumentDto reschedule(String peppolId, UUID id, Instant schedule, String tokenValue) {
+        Document document = documentRepository.findById(id).orElseThrow(() -> new NotFoundException("Document does not exist"));
+        if (!peppolId.equals(document.getOwnerPeppolId())) {
+            throw new SecurityException(AppErrorCodes.PEPPOL_ID_MISMATCH);
+        }
+        if (document.getProcessedOn() != null) {
+            throw new ConflictException("Document is already processed"); //TODO : port to 409 Conflict ?
+        }
+        if (document.getProxyOn() == null) {
+            throw new ConflictException("Document is not yet sent to proxy");
+        }
+        document.setScheduledOn(schedule);
+        document = rescheduleAtProxy(document, tokenValue);
         return DocumentMapper.toDto(document);
     }
 
@@ -354,7 +370,7 @@ public class DocumentService {
         return documentRepository.save(document);
     }
 
-    private Document deliverOnSchedule(Document document, String tokenValue) { //TODO : use boolean noArchive from Company
+    private Document rescheduleAtProxy(Document document, String tokenValue) { //TODO : use boolean noArchive from Company
         UblDocumentDto ublDocumentDto = proxyWebClient.put()
                 .uri("/sapi/document/" + document.getId() + "/send")
                 .headers(headers -> headers.setBearerAuth(tokenValue))

--- a/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
+++ b/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
@@ -372,7 +372,7 @@ public class DocumentService {
 
     private Document rescheduleAtProxy(Document document, String tokenValue) { //TODO : use boolean noArchive from Company
         UblDocumentDto ublDocumentDto = proxyWebClient.put()
-                .uri("/sapi/document/" + document.getId() + "/send")
+                .uri("/sapi/document/" + document.getId() + "/reschedule")
                 .headers(headers -> headers.setBearerAuth(tokenValue))
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(new UblDocumentDto(

--- a/app/backend/src/main/java/org/letspeppol/app/service/ProductService.java
+++ b/app/backend/src/main/java/org/letspeppol/app/service/ProductService.java
@@ -45,6 +45,7 @@ public class ProductService {
         product.setCostPrice(productDto.costPrice());
         product.setSalePrice(productDto.salePrice());
         product.setTaxPercentage(productDto.taxPercentage());
+        product.setStockQuantity(productDto.stockQuantity());
         product.setCompany(company);
 
         if (productDto.categoryId() != null) {
@@ -71,6 +72,7 @@ public class ProductService {
         product.setCostPrice(productDto.costPrice());
         product.setSalePrice(productDto.salePrice());
         product.setTaxPercentage(productDto.taxPercentage());
+        product.setStockQuantity(productDto.stockQuantity());
 
         if (productDto.categoryId() != null) {
             ProductCategory category = productCategoryRepository.findById(productDto.categoryId())

--- a/app/ui/src/account/account.html
+++ b/app/ui/src/account/account.html
@@ -63,8 +63,8 @@
                         <input type="text" value.bind="company.name" disabled />
                     </label>
                     <label class="field">
-                        <span t="account.company-display-name">Company display name</span>
-                        <input type="text" value.bind="company.displayName" />
+                        <span t="label.peppolId">Peppol ID</span>
+                        <input type="text" value.bind="company.peppolId" disabled />
                     </label>
                     <label class="field full">
                         <span t="account.peppol-registration">Peppol Registration</span>
@@ -88,6 +88,10 @@
                     <h2 t="account.address">Address</h2>
                 </div>
                 <div class="grid grid-col-73">
+                    <label class="field full">
+                        <span t="account.company-display-name">Company display name</span>
+                        <input type="text" value.bind="company.displayName" />
+                    </label>
                     <label class="field">
                         <span t="label.city">City</span>
                         <input type="text" value.bind="company.registeredOffice.city" />

--- a/app/ui/src/account/change-password-modal.html
+++ b/app/ui/src/account/change-password-modal.html
@@ -1,3 +1,5 @@
+<import from="../components/choose-password/choose-password"></import>
+
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
     <div class="modal-card" style="width: 300px" keydown.trigger="onKeyDown($event)">
@@ -7,23 +9,14 @@
         </header>
         <div class="modal-body">
             <form class="auth-form">
-                <div class="grid">
-                    <label class="field full">
-                        <span t="label.password">Password</span>
-                        <input name="new-password" type="password" required value.bind="password" />
-                    </label>
-                    <label class="field full">
-                        <span t="label.confirm-password">Password</span>
-                        <input name="new-password" type="password" required value.bind="confirmPassword" />
-                    </label>
-                </div>
+                <choose-password component.ref="choosePassword" password.two-way="password" confirm-password.two-way="confirmPassword" show-heading.bind="true"></choose-password>
                 <p if.bind="error" class="form-error" t="forgot.reset-failed">Change password failed</p>
             </form>
         </div>
         <footer class="modal-footer">
             <button type="button" class="btn" title="Cancel" t="[title]common.cancel" click.trigger="closeModal()" t="common.cancel">Cancel</button>
             <button type="button" class="btn primary"
-                    disabled.bind="!password || password !== confirmPassword || password.length < 8 || isRequesting"
+                    disabled.bind="!password || !choosePassword || !choosePassword.rules.matchOk || !choosePassword.rules.pwStrong || isRequesting"
                     title="Confirm" t="[title]common.confirm"
                     click.trigger="changePassword()" t="common.confirm">Confirm</button>
         </footer>

--- a/app/ui/src/account/change-password-modal.html
+++ b/app/ui/src/account/change-password-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card" style="width: 300px">
+    <div class="modal-card" style="width: 300px" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h3 t="account.change-password">Change Password</h3>
             <button class="icon-btn" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close" click.trigger="closeModal()">×</button>

--- a/app/ui/src/account/change-password-modal.html
+++ b/app/ui/src/account/change-password-modal.html
@@ -9,7 +9,7 @@
         </header>
         <div class="modal-body">
             <form class="auth-form">
-                <choose-password component.ref="choosePassword" password.two-way="password" confirm-password.two-way="confirmPassword" show-heading.bind="true"></choose-password>
+                <choose-password component.ref="choosePassword" password.two-way="password" confirm-password.two-way="confirmPassword"></choose-password>
                 <p if.bind="error" class="form-error" t="forgot.reset-failed">Change password failed</p>
             </form>
         </div>

--- a/app/ui/src/account/change-password-modal.ts
+++ b/app/ui/src/account/change-password-modal.ts
@@ -4,6 +4,7 @@ import {AlertType} from "../components/alert/alert";
 import {computed, IEventAggregator} from "aurelia";
 import {I18N} from "@aurelia/i18n";
 import {ChoosePassword} from "../components/choose-password/choose-password";
+import {onModalEnter} from "../components/util/modal-keyboard";
 
 export class ChangePasswordModal {
     private readonly ea: IEventAggregator = resolve(IEventAggregator);
@@ -48,22 +49,10 @@ export class ChangePasswordModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.changePassword();
+        onModalEnter(event, () => this.changePassword());
     }
 
     private canConfirm() {
         return !!this.password && !!this.choosePassword?.rules.matchOk && !!this.choosePassword?.rules.pwStrong && !this.isRequesting;
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/account/change-password-modal.ts
+++ b/app/ui/src/account/change-password-modal.ts
@@ -20,6 +20,9 @@ export class ChangePasswordModal {
     }
 
     async changePassword() {
+        if (!this.canConfirm()) {
+            return;
+        }
         const request = {
             password: this.password,
         } as ChangePasswordRequest;
@@ -40,5 +43,25 @@ export class ChangePasswordModal {
 
     closeModal() {
         this.open = false;
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.changePassword();
+    }
+
+    private canConfirm() {
+        return !!this.password && this.password === this.confirmPassword && this.password.length >= 8 && !this.isRequesting;
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/account/change-password-modal.ts
+++ b/app/ui/src/account/change-password-modal.ts
@@ -3,6 +3,7 @@ import {ChangePasswordRequest, PasswordService} from "../services/kyc/password-s
 import {AlertType} from "../components/alert/alert";
 import {computed, IEventAggregator} from "aurelia";
 import {I18N} from "@aurelia/i18n";
+import {ChoosePassword} from "../components/choose-password/choose-password";
 
 export class ChangePasswordModal {
     private readonly ea: IEventAggregator = resolve(IEventAggregator);
@@ -12,6 +13,7 @@ export class ChangePasswordModal {
     error: boolean = false;
     password: string;
     confirmPassword: string;
+    choosePassword: ChoosePassword;
 
     public showChangePasswordModal() {
         this.password = '';
@@ -54,7 +56,7 @@ export class ChangePasswordModal {
     }
 
     private canConfirm() {
-        return !!this.password && this.password === this.confirmPassword && this.password.length >= 8 && !this.isRequesting;
+        return !!this.password && !!this.choosePassword?.rules.matchOk && !!this.choosePassword?.rules.pwStrong && !this.isRequesting;
     }
 
     private shouldIgnoreEnter(target: EventTarget | null) {

--- a/app/ui/src/app/lets-peppol.css
+++ b/app/ui/src/app/lets-peppol.css
@@ -716,6 +716,65 @@ main.container {
     gap: .25rem;
 }
 
+.sort-button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-035);
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-weight: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.sort-indicator {
+    position: relative;
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 10px;
+    height: 14px;
+    flex: 0 0 auto;
+}
+
+.sort-indicator::before,
+.sort-indicator::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    opacity: 0.35;
+}
+
+.sort-indicator::before {
+    top: 0;
+    border-bottom: 5px solid var(--muted);
+}
+
+.sort-indicator::after {
+    bottom: 0;
+    border-top: 5px solid var(--muted);
+}
+
+.sort-indicator.is-asc::before,
+.sort-indicator.is-desc::after {
+    opacity: 1;
+    border-bottom-color: var(--text);
+    border-top-color: var(--text);
+}
+
+.sort-indicator.is-idle::before,
+.sort-indicator.is-idle::after {
+    opacity: 0.35;
+}
+
 .filter-toggle {
     font-size: .95rem;
     color: var(--muted);

--- a/app/ui/src/app/lets-peppol.css
+++ b/app/ui/src/app/lets-peppol.css
@@ -959,6 +959,9 @@ main.container .data-table tbody td {
 .modal-card {
     position: relative;
     width: min(var(--modal-max-w), calc(100% - var(--space-2rem)));
+    max-height: calc(100vh - var(--space-2rem));
+    display: flex;
+    flex-direction: column;
     background: var(--panel);
     border: 1px solid var(--border-soft);
     border-radius: var(--radius-md);
@@ -979,7 +982,9 @@ main.container .data-table tbody td {
 }
 
 .modal-body {
+    min-height: 0;
     padding: 0 var(--space-1) var(--space-1);
+    overflow: auto;
 }
 
 .modal-footer {

--- a/app/ui/src/app/locale/translation_de.json
+++ b/app/ui/src/app/locale/translation_de.json
@@ -140,6 +140,15 @@
     "INVOICE" : "Rechnung",
     "CREDIT_NOTE" : "Gutschrift"
   },
+  "password-rules": {
+    "length": "Mindestens 12 Zeichen",
+    "lower": "Mindestens 1 Kleinbuchstabe",
+    "upper": "Mindestens 1 Großbuchstabe",
+    "number": "Mindestens 1 Zahl",
+    "symbol": "Mindestens 1 Symbol",
+    "match": "Passwörter stimmen überein",
+    "strength": "Passwortstärke"
+  },
   "confirmation": {
     "header": "Identität bestätigen",
     "header-sign": "Vertrag unterschreiben",

--- a/app/ui/src/app/locale/translation_en.json
+++ b/app/ui/src/app/locale/translation_en.json
@@ -140,6 +140,15 @@
     "INVOICE" : "Invoice",
     "CREDIT_NOTE" : "Credit Note"
   },
+  "password-rules": {
+    "length": "At least 12 characters",
+    "lower": "At least 1 lowercase letter",
+    "upper": "At least 1 uppercase letter",
+    "number": "At least 1 number",
+    "symbol": "At least 1 symbol",
+    "match": "Passwords match",
+    "strength": "Password strength"
+  },
   "confirmation": {
     "header": "Confirm Identity",
     "header-sign": "Sign Contract",

--- a/app/ui/src/app/locale/translation_fr.json
+++ b/app/ui/src/app/locale/translation_fr.json
@@ -139,6 +139,15 @@
     "INVOICE" : "Facture",
     "CREDIT_NOTE" : "Note de crédit"
   },
+  "password-rules" : {
+    "length" : "Au moins 12 caractères",
+    "lower" : "Au moins 1 minuscule",
+    "upper" : "Au moins 1 majuscule",
+    "number" : "Au moins 1 chiffre",
+    "symbol" : "Au moins 1 symbole",
+    "match" : "Les mots de passe correspondent",
+    "strength" : "Robustesse du mot de passe"
+  },
   "confirmation" : {
     "header" : "Confirmer l'identité",
     "header-sign" : "Signer le contrat",

--- a/app/ui/src/app/locale/translation_nl.json
+++ b/app/ui/src/app/locale/translation_nl.json
@@ -139,6 +139,15 @@
     "INVOICE" : "Factuur",
     "CREDIT_NOTE" : "Creditnota"
   },
+  "password-rules" : {
+    "length" : "Minstens 12 tekens",
+    "lower" : "Minstens 1 kleine letter",
+    "upper" : "Minstens 1 hoofdletter",
+    "number" : "Minstens 1 cijfer",
+    "symbol" : "Minstens 1 symbool",
+    "match" : "Wachtwoorden komen overeen",
+    "strength" : "Wachtwoordsterkte"
+  },
   "confirmation" : {
     "header" : "Identiteit bevestigen",
     "header-sign" : "Contract ondertekenen",

--- a/app/ui/src/components/choose-password/choose-password.css
+++ b/app/ui/src/components/choose-password/choose-password.css
@@ -1,0 +1,17 @@
+.pw-hints {
+    margin: .5rem 0 0;
+    padding-left: 1rem;
+}
+
+.pw-hints li {
+    color: #b33;
+}
+
+.pw-hints li.ok {
+    color: #2a7;
+}
+
+meter {
+    width: 100%;
+    height: .5rem;
+}

--- a/app/ui/src/components/choose-password/choose-password.html
+++ b/app/ui/src/components/choose-password/choose-password.html
@@ -1,0 +1,26 @@
+<import from="./choose-password.css"></import>
+
+<template>
+    <h3 if.bind="showHeading" t="confirmation.choose-credentials-title">Choose Credentials</h3>
+    <div class="grid single">
+        <label class="field full">
+            <span t="label.password">Password</span>
+            <input name="password" type="password" value.two-way="password" />
+        </label>
+        <label class="field full">
+            <span t="label.confirm-password">Confirm password</span>
+            <input name="confirm-password" type="password" value.two-way="confirmPassword" />
+        </label>
+    </div>
+    <template if.bind="password">
+        <ul class="pw-hints">
+            <li class.bind="rules.lengthOk ? 'ok' : ''">At least 12 characters</li>
+            <li class.bind="rules.lowerOk ? 'ok' : ''">At least 1 lower</li>
+            <li class.bind="rules.upperOk ? 'ok' : ''">At least 1 UPPER</li>
+            <li class.bind="rules.numberOk ? 'ok' : ''">At least 1 number</li>
+            <li class.bind="rules.symbolOk ? 'ok' : ''">At least 1 symbol</li>
+            <li class.bind="rules.matchOk ? 'ok' : ''">Passwords match</li>
+        </ul>
+        <meter min="0" max="8" low="4" high="7" optimum="8" value.bind="rules.pwScore" aria-label="Password strength"></meter>
+    </template>
+</template>

--- a/app/ui/src/components/choose-password/choose-password.html
+++ b/app/ui/src/components/choose-password/choose-password.html
@@ -14,13 +14,13 @@
     </div>
     <template if.bind="password">
         <ul class="pw-hints">
-            <li class.bind="rules.lengthOk ? 'ok' : ''">At least 12 characters</li>
-            <li class.bind="rules.lowerOk ? 'ok' : ''">At least 1 lower</li>
-            <li class.bind="rules.upperOk ? 'ok' : ''">At least 1 UPPER</li>
-            <li class.bind="rules.numberOk ? 'ok' : ''">At least 1 number</li>
-            <li class.bind="rules.symbolOk ? 'ok' : ''">At least 1 symbol</li>
-            <li class.bind="rules.matchOk ? 'ok' : ''">Passwords match</li>
+            <li class.bind="rules.lengthOk ? 'ok' : ''" t="password-rules.length">At least 12 characters</li>
+            <li class.bind="rules.lowerOk ? 'ok' : ''" t="password-rules.lower">At least 1 lowercase letter</li>
+            <li class.bind="rules.upperOk ? 'ok' : ''" t="password-rules.upper">At least 1 uppercase letter</li>
+            <li class.bind="rules.numberOk ? 'ok' : ''" t="password-rules.number">At least 1 number</li>
+            <li class.bind="rules.symbolOk ? 'ok' : ''" t="password-rules.symbol">At least 1 symbol</li>
+            <li class.bind="rules.matchOk ? 'ok' : ''" t="password-rules.match">Passwords match</li>
         </ul>
-        <meter min="0" max="8" low="4" high="7" optimum="8" value.bind="rules.pwScore" aria-label="Password strength"></meter>
+        <meter min="0" max="8" low="4" high="7" optimum="8" value.bind="rules.pwScore" t="[aria-label]password-rules.strength" aria-label="Password strength"></meter>
     </template>
 </template>

--- a/app/ui/src/components/choose-password/choose-password.ts
+++ b/app/ui/src/components/choose-password/choose-password.ts
@@ -1,0 +1,47 @@
+import {bindable} from "aurelia";
+
+export interface PasswordRuleState {
+    lengthOk: boolean;
+    lowerOk: boolean;
+    upperOk: boolean;
+    numberOk: boolean;
+    symbolOk: boolean;
+    matchOk: boolean;
+    pwScore: number;
+    pwStrong: boolean;
+}
+
+export class ChoosePassword {
+    @bindable password = '';
+    @bindable confirmPassword = '';
+    @bindable showHeading = false;
+
+    get rules(): PasswordRuleState {
+        const value = this.password ?? '';
+        const confirmation = this.confirmPassword ?? '';
+        const lengthOk = value.length >= 12;
+        const lowerOk = /[a-z]/.test(value);
+        const upperOk = /[A-Z]/.test(value);
+        const numberOk = /\d/.test(value);
+        const symbolOk = /[^A-Za-z0-9]/.test(value);
+        const matchOk = !!value && value === confirmation;
+        const pwScore = value
+            ? Math.min(4, Math.floor(value.length / 4))
+                + (lowerOk ? 1 : 0)
+                + (upperOk ? 1 : 0)
+                + (numberOk ? 1 : 0)
+                + (symbolOk ? 1 : 0)
+            : 0;
+
+        return {
+            lengthOk,
+            lowerOk,
+            upperOk,
+            numberOk,
+            symbolOk,
+            matchOk,
+            pwScore,
+            pwStrong: lengthOk && lowerOk && upperOk && numberOk && symbolOk,
+        };
+    }
+}

--- a/app/ui/src/components/confirmation/confirmation-modal.html
+++ b/app/ui/src/components/confirmation/confirmation-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="confirmationContext.open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card" style="width: 300px">
+    <div class="modal-card" style="width: 300px" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h3>${confirmationContext.title}</h3>
             <button class="icon-btn" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close" click.trigger="no()">×</button>

--- a/app/ui/src/components/confirmation/confirmation-modal.ts
+++ b/app/ui/src/components/confirmation/confirmation-modal.ts
@@ -17,4 +17,20 @@ export class ConfirmationModal {
         }
         this.confirmationContext.open = false;
     }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.yes();
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+    }
 }

--- a/app/ui/src/components/confirmation/confirmation-modal.ts
+++ b/app/ui/src/components/confirmation/confirmation-modal.ts
@@ -1,5 +1,6 @@
 import {resolve} from "@aurelia/kernel";
 import {ConfirmationModalContext} from "./confirmation-modal-context";
+import {onModalEnter} from "../util/modal-keyboard";
 
 export class ConfirmationModal {
     private readonly confirmationContext = resolve(ConfirmationModalContext);
@@ -19,18 +20,6 @@ export class ConfirmationModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.yes();
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+        onModalEnter(event, () => this.yes());
     }
 }

--- a/app/ui/src/components/donations/donations.css
+++ b/app/ui/src/components/donations/donations.css
@@ -8,7 +8,7 @@
     margin: 0 auto;
     display: flex;
     flex-direction: column;
-    z-index: 60;
+    z-index: 40;
     padding: 0
 }
 

--- a/app/ui/src/components/donations/sponsor-payment-modal.html
+++ b/app/ui/src/components/donations/sponsor-payment-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card sponsor-payment-modal">
+    <div class="modal-card sponsor-payment-modal" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h2 t="donations.sponsor-payment.title">Donate to sponsor Let’s Peppol</h2>
             <button class="icon-btn" click.trigger="closeModal()" aria-label="Close dialog" title="Close" t="[aria-label]common.close;[title]common.close">×</button>

--- a/app/ui/src/components/donations/sponsor-payment-modal.ts
+++ b/app/ui/src/components/donations/sponsor-payment-modal.ts
@@ -1,4 +1,5 @@
 import {IEventAggregator} from "aurelia";
+import {onModalEnter} from "../util/modal-keyboard";
 import {resolve} from "@aurelia/kernel";
 import {I18N} from "@aurelia/i18n";
 import {CompanyService} from "../../services/app/company-service";
@@ -184,27 +185,10 @@ export class SponsorPaymentModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        if (this.sent) {
-            event.preventDefault();
-            this.closeModal();
-            return;
-        }
-        event.preventDefault();
-        this.sponsor();
+        onModalEnter(event, () => this.sent ? this.closeModal() : this.sponsor());
     }
 
     private canConfirm() {
         return !!this.validAmount && !this.sending;
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/components/donations/sponsor-payment-modal.ts
+++ b/app/ui/src/components/donations/sponsor-payment-modal.ts
@@ -123,7 +123,7 @@ export class SponsorPaymentModal {
     }
 
     async sponsor() {
-        if (!this.validAmount || this.sending) {
+        if (!this.canConfirm()) {
             return;
         }
         this.sending = true;
@@ -181,5 +181,30 @@ export class SponsorPaymentModal {
 
     private truncate(value: string, maxLength: number) {
         return value.length > maxLength ? value.slice(0, maxLength) : value;
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        if (this.sent) {
+            event.preventDefault();
+            this.closeModal();
+            return;
+        }
+        event.preventDefault();
+        this.sponsor();
+    }
+
+    private canConfirm() {
+        return !!this.validAmount && !this.sending;
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/components/util/modal-keyboard.ts
+++ b/app/ui/src/components/util/modal-keyboard.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns true when pressing Enter on the given target should NOT trigger a modal's
+ * primary action (e.g. when focus is on a button, link or textarea).
+ */
+export function shouldIgnoreEnter(target: EventTarget | null): boolean {
+    const element = target as HTMLElement | null;
+    if (!element) {
+        return false;
+    }
+    return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+}
+
+/**
+ * Runs the given action when Enter is pressed on a modal, unless focus is on an element
+ * where Enter has its own meaning. Prevents the default form submission/newline behaviour.
+ */
+export function onModalEnter(event: KeyboardEvent, action: () => void): void {
+    if (event.key !== 'Enter' || shouldIgnoreEnter(event.target)) {
+        return;
+    }
+    event.preventDefault();
+    action();
+}

--- a/app/ui/src/invoice/edit/components/invoice-edit-items.ts
+++ b/app/ui/src/invoice/edit/components/invoice-edit-items.ts
@@ -1,6 +1,6 @@
 import {resolve} from "@aurelia/kernel";
 import {InvoiceContext} from "../../invoice-context";
-import {ClassifiedTaxCategory, CreditNoteLine, getAmount, InvoiceLine, UBLLine} from "../../../services/peppol/ubl";
+import {ClassifiedTaxCategory, CreditNoteLine, getAmount, InvoiceLine, normalizeLinePrice, UBLLine} from "../../../services/peppol/ubl";
 import {InvoiceCalculator, roundTwoDecimals} from "../../invoice-calculator";
 import {DocumentType} from "../../../services/app/invoice-service";
 import {bindable} from "aurelia";
@@ -32,15 +32,7 @@ export class InvoiceEditItems {
 
     calcLineTotal(line: UBLLine) {
         const quantity = getAmount(line);
-        if (!line.Price) {
-            line.Price = { PriceAmount: { value: 0 } } as UBLLine["Price"];
-        }
-        if (!line.Price.PriceAmount) {
-            line.Price.PriceAmount = { value: 0 };
-        }
-        const rawUnitPrice = Number(line.Price.PriceAmount.value);
-        const unitPrice = Number.isFinite(rawUnitPrice) && rawUnitPrice >= 0 ? rawUnitPrice : 0;
-        line.Price.PriceAmount.value = unitPrice;
+        const unitPrice = normalizeLinePrice(line);
         line.LineExtensionAmount.value = roundTwoDecimals(unitPrice * quantity.value);
         this.invoiceCalculator.calculateTaxAndTotals(this.invoiceContext.selectedInvoice);
         this.checkLineAutoSave(line);

--- a/app/ui/src/invoice/edit/components/invoice-edit-items.ts
+++ b/app/ui/src/invoice/edit/components/invoice-edit-items.ts
@@ -32,7 +32,16 @@ export class InvoiceEditItems {
 
     calcLineTotal(line: UBLLine) {
         const quantity = getAmount(line);
-        line.LineExtensionAmount.value = roundTwoDecimals(line.Price.PriceAmount.value * quantity.value);
+        if (!line.Price) {
+            line.Price = { PriceAmount: { value: 0 } } as UBLLine["Price"];
+        }
+        if (!line.Price.PriceAmount) {
+            line.Price.PriceAmount = { value: 0 };
+        }
+        const rawUnitPrice = Number(line.Price.PriceAmount.value);
+        const unitPrice = Number.isFinite(rawUnitPrice) && rawUnitPrice >= 0 ? rawUnitPrice : 0;
+        line.Price.PriceAmount.value = unitPrice;
+        line.LineExtensionAmount.value = roundTwoDecimals(unitPrice * quantity.value);
         this.invoiceCalculator.calculateTaxAndTotals(this.invoiceContext.selectedInvoice);
         this.checkLineAutoSave(line);
     }
@@ -64,7 +73,7 @@ export class InvoiceEditItems {
 
     checkLineAutoSave(line: InvoiceLine | CreditNoteLine) {
         let autosave = false;
-        if (line?.Item?.Name && line?.Price?.PriceAmount?.value) {
+        if (line?.Item?.Name && line?.Price?.PriceAmount?.value != null) {
             if (this.invoiceContext.selectedDocumentType === DocumentType.INVOICE && (line as InvoiceLine).InvoicedQuantity?.value
                 || this.invoiceContext.selectedDocumentType === DocumentType.CREDIT_NOTE && (line as CreditNoteLine).CreditedQuantity?.value) {
                 autosave = true;

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.html
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card" style="width: 800px">
+    <div class="modal-card" style="width: 800px" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h2>Attachments</h2>
             <button class="icon-btn" click.trigger="closeModal()" aria-label="Close dialog" title="Close" t="[title]common.close">×</button>

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
@@ -1,4 +1,5 @@
 import {bindable, IEventAggregator, watch} from "aurelia";
+import {onModalEnter} from "../../../../components/util/modal-keyboard";
 import {AdditionalDocumentReference} from "../../../../services/peppol/ubl";
 import {resolve} from "@aurelia/kernel";
 import {AlertType} from "../../../../components/alert/alert";
@@ -148,18 +149,6 @@ export class InvoiceAttachmentModal {
     });
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.saveAttachments();
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+        onModalEnter(event, () => this.saveAttachments());
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
@@ -47,6 +47,9 @@ export class InvoiceAttachmentModal {
     }
 
     saveAttachments() {
+        if (!this.validated) {
+            return;
+        }
         this.invoiceContext.selectedInvoice.AdditionalDocumentReference = this.additionalDocumentReference;
         this.closeModal();
     }
@@ -143,4 +146,20 @@ export class InvoiceAttachmentModal {
         reader.onload = () => resolve(reader.result);
         reader.onerror = reject;
     });
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.saveAttachments();
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+    }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
@@ -140,10 +140,10 @@ export class InvoiceAttachmentModal {
         return true;
     }
 
-    toBase64 = file => new Promise((resolve, reject) => {
+    toBase64 = (file: File): Promise<string> => new Promise((resolve, reject) => {
         const reader = new FileReader();
         reader.readAsDataURL(file);
-        reader.onload = () => resolve(reader.result);
+        reader.onload = () => resolve(reader.result as string);
         reader.onerror = reject;
     });
 

--- a/app/ui/src/invoice/edit/components/modals/invoice-customer-modal.html
+++ b/app/ui/src/invoice/edit/components/modals/invoice-customer-modal.html
@@ -3,7 +3,7 @@
 
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card" style="width: 800px">
+    <div class="modal-card" style="width: 800px" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h2 t="invoice.customerModal.title">Customer</h2>
             <button class="icon-btn" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close" click.trigger="closeModal()">×</button>

--- a/app/ui/src/invoice/edit/components/modals/invoice-customer-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-customer-modal.ts
@@ -1,4 +1,5 @@
 import {bindable, IEventAggregator} from "aurelia";
+import {onModalEnter} from "../../../../components/util/modal-keyboard";
 import {Identifier, Party} from "../../../../services/peppol/ubl";
 import {PartnerDto, PartnerService} from "../../../../services/app/partner-service";
 import {CustomerSearch} from "../customer-search";
@@ -212,11 +213,7 @@ export class InvoiceCustomerModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.saveCustomer();
+        onModalEnter(event, () => this.saveCustomer());
     }
 
     private canConfirm() {
@@ -225,13 +222,5 @@ export class InvoiceCustomerModal {
             && !!this.customer?.PartyTaxScheme?.CompanyID
             && !!this.peppolId
             && this.peppolId.includes(':');
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-customer-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-customer-modal.ts
@@ -60,6 +60,9 @@ export class InvoiceCustomerModal {
     }
 
     saveCustomer() {
+        if (!this.canConfirm()) {
+            return;
+        }
         this.open = false;
         const previousPeppolId = this.toPeppolIdString(this.invoiceContext.selectedInvoice.AccountingCustomerParty.Party?.EndpointID);
         const newPeppolId = this.toPeppolIdString(this.customer?.EndpointID);
@@ -206,5 +209,29 @@ export class InvoiceCustomerModal {
         if (!this.customer.PostalAddress.StreetName) {
             this.customer.PostalAddress.StreetName = kycCompanyResponse.street;
         }
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.saveCustomer();
+    }
+
+    private canConfirm() {
+        return !!this.customer?.PartyName?.Name
+            && !!this.customer?.PartyLegalEntity?.RegistrationName
+            && !!this.customer?.PartyTaxScheme?.CompanyID
+            && !!this.peppolId
+            && this.peppolId.includes(':');
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-date-modal.html
+++ b/app/ui/src/invoice/edit/components/modals/invoice-date-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card">
+    <div class="modal-card" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h2 t="invoice.dateModal.title">Date</h2>
             <button class="icon-btn" click.trigger="closeModal()" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close">×</button>

--- a/app/ui/src/invoice/edit/components/modals/invoice-date-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-date-modal.ts
@@ -56,6 +56,9 @@ export class InvoiceDateModal {
     }
 
     private saveDate() {
+        if (!this.issueDate) {
+            return;
+        }
         this.open = false;
         this.invoiceContext.selectedInvoice.IssueDate = this.issueDate;
         this.invoiceContext.selectedInvoice.DueDate = this.dueDate;
@@ -79,5 +82,21 @@ export class InvoiceDateModal {
         if (selectedPaymentTerm) {
             setTimeout(() => this.selectedPaymentTerm = selectedPaymentTerm, 100);
         }
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.saveDate();
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-date-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-date-modal.ts
@@ -1,4 +1,5 @@
 import {bindable, observable} from "aurelia";
+import {onModalEnter} from "../../../../components/util/modal-keyboard";
 import {resolve} from "@aurelia/kernel";
 import {Account} from "../../../../account/account";
 import {InvoiceComposer} from "../../../invoice-composer";
@@ -85,18 +86,6 @@ export class InvoiceDateModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.saveDate();
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+        onModalEnter(event, () => this.saveDate());
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-number-modal.html
+++ b/app/ui/src/invoice/edit/components/modals/invoice-number-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card">
+    <div class="modal-card" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h2 t="${isCreditNote ? 'invoice.modal.credit-note-number' : 'invoice.modal.invoice-number'}">Invoice Number</h2>
             <button class="icon-btn" click.trigger="closeModal()" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close">×</button>

--- a/app/ui/src/invoice/edit/components/modals/invoice-number-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-number-modal.ts
@@ -22,10 +22,29 @@ export class InvoiceNumberModal {
     }
 
     sendInvoice() {
+        if (!this.invoiceNumber) {
+            return;
+        }
         this.invoiceContext.selectedInvoice.ID = this.invoiceNumber;
         if (this.sendFunction) {
             this.sendFunction();
             this.open = false;
         }
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.sendInvoice();
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-number-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-number-modal.ts
@@ -1,4 +1,5 @@
 import {bindable} from "aurelia";
+import {onModalEnter} from "../../../../components/util/modal-keyboard";
 import {DocumentType} from "../../../../services/app/invoice-service";
 
 export class InvoiceNumberModal {
@@ -33,18 +34,6 @@ export class InvoiceNumberModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.sendInvoice();
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+        onModalEnter(event, () => this.sendInvoice());
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-payment-modal.html
+++ b/app/ui/src/invoice/edit/components/modals/invoice-payment-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card">
+    <div class="modal-card" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h2 t="invoice.paymentModal.title">Payment</h2>
             <button class="icon-btn" click.trigger="closeModal()" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close">×</button>

--- a/app/ui/src/invoice/edit/components/modals/invoice-payment-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-payment-modal.ts
@@ -1,4 +1,5 @@
 import {bindable, IEventAggregator} from "aurelia";
+import {onModalEnter} from "../../../../components/util/modal-keyboard";
 import {PaymentMeans} from "../../../../services/peppol/ubl";
 import {InvoiceComposer} from "../../../invoice-composer";
 import {resolve} from "@aurelia/kernel";
@@ -60,18 +61,6 @@ export class InvoicePaymentModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.savePaymentMeans();
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+        onModalEnter(event, () => this.savePaymentMeans());
     }
 }

--- a/app/ui/src/invoice/edit/components/modals/invoice-payment-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-payment-modal.ts
@@ -28,6 +28,9 @@ export class InvoicePaymentModal {
     }
 
     savePaymentMeans() {
+        if (this.paymentMeansCode === 30 && !this.paymentMeans?.PayeeFinancialAccount?.ID) {
+            return;
+        }
         this.open = false;
         this.invoiceContext.selectedInvoice.PaymentMeans = this.paymentMeans;
     }
@@ -54,5 +57,21 @@ export class InvoicePaymentModal {
         } catch {
             this.ea.publish('alert', {alertType: AlertType.Danger, text: this.i18n.tr('alert.company.save-failed')});
         }
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.savePaymentMeans();
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/invoice/edit/invoice-edit.ts
+++ b/app/ui/src/invoice/edit/invoice-edit.ts
@@ -6,6 +6,7 @@ import {
     Invoice,
     CreditNoteLine,
     InvoiceLine,
+    normalizeLinePrice,
     UBLLine
 } from "../../services/peppol/ubl";
 import {AlertType} from "../../components/alert/alert";
@@ -257,14 +258,7 @@ export class InvoiceEdit {
             return;
         }
         for (const line of lines) {
-            if (!line.Price) {
-                line.Price = { PriceAmount: { value: 0 } } as UBLLine["Price"];
-            }
-            if (!line.Price.PriceAmount) {
-                line.Price.PriceAmount = { value: 0 };
-            }
-            const rawUnitPrice = Number(line.Price.PriceAmount.value);
-            line.Price.PriceAmount.value = Number.isFinite(rawUnitPrice) && rawUnitPrice >= 0 ? rawUnitPrice : 0;
+            normalizeLinePrice(line);
         }
     }
 

--- a/app/ui/src/invoice/edit/invoice-edit.ts
+++ b/app/ui/src/invoice/edit/invoice-edit.ts
@@ -119,8 +119,7 @@ export class InvoiceEdit {
             this.ea.publish('alert', {alertType: AlertType.Success, text: this.i18n.tr(`alert.invoice.sent.${type}`)});
             this.invoiceContext.invoicePage.content.unshift(doc);
             if (this.invoiceContext.selectedDocument.draftedOn) {
-                this.invoiceContext.deleteDraft(this.invoiceContext.selectedDocument);
-                this.returnToOverview();
+                await this.deleteDraft();
             } else {
                 this.returnToOverview();
             }

--- a/app/ui/src/invoice/edit/invoice-edit.ts
+++ b/app/ui/src/invoice/edit/invoice-edit.ts
@@ -102,19 +102,23 @@ export class InvoiceEdit {
         const type = this.selectedDocumentType;
         try {
             this.ea.publish('showOverlay', this.i18n.tr(`overlay.sending.${type}`));
-            const xml = this.buildXml();
-
-            const response = await this.invoiceService.validate(xml);
-            if (!response.isValid) {
-                this.validationResultModal.showModal(response);
-                return;
+            let doc;
+            if (this.invoiceContext.selectedDocument?.createdExternally && this.invoiceContext.selectedDocument?.id) {
+                doc = await this.invoiceService.sendDocument(this.invoiceContext.selectedDocument.id);
+            } else {
+                const xml = this.buildXml();
+                const response = await this.invoiceService.validate(xml);
+                if (!response.isValid) {
+                    this.validationResultModal.showModal(response);
+                    return;
+                }
+                doc = await this.invoiceService.createDocument(xml);
             }
-
-            const doc = await this.invoiceService.createDocument(xml);
             this.ea.publish('alert', {alertType: AlertType.Success, text: this.i18n.tr(`alert.invoice.sent.${type}`)});
             this.invoiceContext.invoicePage.content.unshift(doc);
             if (this.invoiceContext.selectedDocument.draftedOn) {
-                await this.deleteDraft();
+                this.invoiceContext.deleteDraft(this.invoiceContext.selectedDocument);
+                this.returnToOverview();
             } else {
                 this.returnToOverview();
             }

--- a/app/ui/src/invoice/edit/invoice-edit.ts
+++ b/app/ui/src/invoice/edit/invoice-edit.ts
@@ -4,6 +4,8 @@ import {bindable, computed, IDisposable, IEventAggregator} from "aurelia";
 import {
     CreditNote,
     Invoice,
+    CreditNoteLine,
+    InvoiceLine,
     UBLLine
 } from "../../services/peppol/ubl";
 import {AlertType} from "../../components/alert/alert";
@@ -142,6 +144,7 @@ export class InvoiceEdit {
     // }
 
     buildXml(): string {
+        this.normalizeUnitPrices();
         if  (this.selectedDocumentType === DocumentType.INVOICE)  {
             return buildInvoiceXml(this.invoiceContext.selectedInvoice as Invoice)
         } else {
@@ -247,6 +250,23 @@ export class InvoiceEdit {
         const response = await this.invoiceService.validate(xml);
         this.validationResultModal.showModal(response);
         console.log(response);
+    }
+
+    private normalizeUnitPrices() {
+        const lines = this.invoiceContext.lines as Array<InvoiceLine | CreditNoteLine> | undefined;
+        if (!lines?.length) {
+            return;
+        }
+        for (const line of lines) {
+            if (!line.Price) {
+                line.Price = { PriceAmount: { value: 0 } } as UBLLine["Price"];
+            }
+            if (!line.Price.PriceAmount) {
+                line.Price.PriceAmount = { value: 0 };
+            }
+            const rawUnitPrice = Number(line.Price.PriceAmount.value);
+            line.Price.PriceAmount.value = Number.isFinite(rawUnitPrice) && rawUnitPrice >= 0 ? rawUnitPrice : 0;
+        }
     }
 
     savePartner() {

--- a/app/ui/src/invoice/overview/invoice-overview.html
+++ b/app/ui/src/invoice/overview/invoice-overview.html
@@ -198,7 +198,7 @@
                 </div>
                 <div class="table-footer pager">
                     <button type="button" class="btn ghost" click.trigger="previousPage()" disabled.bind="query.pageable.page <= 0" t="invoice.pager.previous">← Previous</button>
-                    <span class="pager-range"></span>
+                    <span class="pager-range">${pageStart} - ${pageEnd} / ${invoiceContext.invoicePage?.totalElements ?? 0}</span>
                     <button type="button" class="btn ghost" click.trigger="nextPage()" disabled.bind="invoiceContext.invoicePage.last" t="invoice.pager.next">Next →</button>
                 </div>
             </div>

--- a/app/ui/src/invoice/overview/invoice-overview.html
+++ b/app/ui/src/invoice/overview/invoice-overview.html
@@ -83,10 +83,18 @@
                             <th style="width: 10px"></th>
                             <th t="invoice.table.direction">Direction</th>
                             <th t="invoice.table.type">Type</th>
-                            <th t="invoice.table.doc">Doc</th>
-                            <th class="th-filter" t="invoice.table.issue-date">
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('invoiceReference')">
+                                    <span t="invoice.table.doc">Doc</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='invoiceReference'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th class="th-filter">
                                 <div class="th-inner">
-                                    <span t="invoice.table.issue-date">Date</span>
+                                    <button type="button" class="sort-button" click.trigger="toggleSort('issueDate')">
+                                        <span t="invoice.table.issue-date">Date</span>
+                                        <span class="sort-indicator ${activeSortProperty!=='issueDate'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                    </button>
                                 </div>
                                 <div class="filter-panel" hidden>
                                     <label class="field">
@@ -103,9 +111,12 @@
                                     </div>
                                 </div>
                             </th>
-                            <th class="th-filter" t="invoice.table.due-date">
+                            <th class="th-filter">
                                 <div class="th-inner">
-                                    <span t="invoice.table.due-date">Date</span>
+                                    <button type="button" class="sort-button" click.trigger="toggleSort('dueDate')">
+                                        <span t="invoice.table.due-date">Date</span>
+                                        <span class="sort-indicator ${activeSortProperty!=='dueDate'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                    </button>
                                 </div>
                                 <div class="filter-panel" hidden>
                                     <label class="field">
@@ -123,15 +134,21 @@
                                 </div>
                             </th>
                             <th>
-                                <span if.bind="invoiceContext.activeBox === 'OUTGOING' || invoiceContext.activeBox === 'DRAFTS'" t="invoice.customer">Customer</span>
-                                <span if.bind="invoiceContext.activeBox === 'INCOMING'" t="invoice.supplier">Supplier</span>
-                                <span if.bind="invoiceContext.activeBox === 'ALL'" t="invoice.partner">Partner</span>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('partnerName')">
+                                    <span if.bind="invoiceContext.activeBox === 'OUTGOING' || invoiceContext.activeBox === 'DRAFTS'" t="invoice.customer">Customer</span>
+                                    <span if.bind="invoiceContext.activeBox === 'INCOMING'" t="invoice.supplier">Supplier</span>
+                                    <span if.bind="invoiceContext.activeBox === 'ALL'" t="invoice.partner">Partner</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='partnerName'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
                             </th>
                             <th>
-                                <span class="th-stack">
-                                    <span t="invoice.table.total">Total</span>
-                                    <span class="th-subline" t="invoice.table.total-vat-suffix.${vatMode}"></span>
-                                </span>
+                                <button type="button" class="sort-button" click.trigger="toggleSort(vatMode === 'inclVat' ? 'amountInclVat' : 'amountExclVat')">
+                                    <span class="th-stack">
+                                        <span t="invoice.table.total">Total</span>
+                                        <span class="th-subline" t="invoice.table.total-vat-suffix.${vatMode}"></span>
+                                    </span>
+                                    <span class="sort-indicator ${activeSortProperty!==(vatMode === 'inclVat' ? 'amountInclVat' : 'amountExclVat')?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
                             </th>
                             <th t="invoice.table.status">Status</th>
                             <th class="actions-col" t="invoice.table.actions">Actions</th>

--- a/app/ui/src/invoice/overview/invoice-overview.ts
+++ b/app/ui/src/invoice/overview/invoice-overview.ts
@@ -14,6 +14,8 @@ import {IRouter} from "@aurelia/router";
 import {UploadUblModal} from "./components/upload-ubl-modal";
 import {I18N} from "@aurelia/i18n";
 
+type SortDirection = "asc" | "desc";
+
 export class InvoiceOverview {
     readonly ea: IEventAggregator = resolve(IEventAggregator);
     private invoiceService = resolve(InvoiceService);
@@ -22,7 +24,9 @@ export class InvoiceOverview {
     private readonly i18n = resolve(I18N);
     private vatDisplay = resolve(IVatDisplay);
     vatMode: VatDisplayMode = this.vatDisplay.mode;
-    query: DocumentQuery = {pageable: {page: 0, size: 20}};
+    query: DocumentQuery = {pageable: {page: 0, size: 20, sort: [{property: 'issueDate', direction: 'desc'}]}};
+    activeSortProperty = 'issueDate';
+    activeSortDirection: SortDirection = 'desc';
     private resetSubscription: IDisposable;
     private vatUnsubscribe: () => void;
 
@@ -49,16 +53,22 @@ export class InvoiceOverview {
     }
 
     @watch((vm) => [vm.query.invoiceReference, vm.query.partnerName])
+    queryChanged() {
+        this.query.pageable.page = 0;
+        this.reloadCurrentView();
+    }
+
     loadInvoices() {
         this.invoiceService.getDocuments({
             ...this.query,
-            draft: this.invoiceContext.activeBox === 'drafts'
+            draft: this.invoiceContext.activeBox === 'DRAFTS'
         }).then(page => this.invoiceContext.invoicePage = page);
     }
 
     changeDocType(value: DocumentType) {
         this.query.type = value;
-        this.loadInvoices();
+        this.query.pageable.page = 0;
+        this.reloadCurrentView();
     }
 
     setActiveItems(box) {
@@ -66,15 +76,18 @@ export class InvoiceOverview {
         switch (box) {
             case 'ALL':
                 this.query.direction = undefined;
+                this.query.pageable.page = 0;
                 this.loadInvoices();
                 break;
             case DocumentDirection.INCOMING:
             case DocumentDirection.OUTGOING:
                 this.query.direction = box;
+                this.query.pageable.page = 0;
                 this.loadInvoices();
                 break;
             case 'DRAFTS':
-                this.invoiceContext.invoicePage = this.invoiceContext.draftPage;
+                this.query.pageable.page = 0;
+                this.loadDrafts();
                 break;
         }
     }
@@ -101,7 +114,17 @@ export class InvoiceOverview {
             return;
         }
         this.query.pageable.page--;
-        this.loadInvoices();
+        this.reloadCurrentView();
+    }
+
+    toggleSort(property: string) {
+        const currentDirection = this.sortDirection(property);
+        const direction: SortDirection = currentDirection === 'asc' ? 'desc' : 'asc';
+        this.query.pageable.sort = [{property, direction}];
+        this.activeSortProperty = property;
+        this.activeSortDirection = direction;
+        this.query.pageable.page = 0;
+        this.reloadCurrentView();
     }
 
     isOverdue(item: DocumentDto) {
@@ -147,5 +170,17 @@ export class InvoiceOverview {
 
     showUploadUblModal() {
         this.uploadUblModal.showModal();
+    }
+
+    private reloadCurrentView() {
+        if (this.invoiceContext.activeBox === 'DRAFTS') {
+            this.loadDrafts();
+            return;
+        }
+        this.loadInvoices();
+    }
+
+    private sortDirection(property: string): SortDirection | undefined {
+        return this.query.pageable.sort?.find(sort => sort.property === property)?.direction;
     }
 }

--- a/app/ui/src/invoice/overview/invoice-overview.ts
+++ b/app/ui/src/invoice/overview/invoice-overview.ts
@@ -97,7 +97,7 @@ export class InvoiceOverview {
     }
 
     previousPage() {
-        if (this.query.pageable.page === 1) {
+        if (this.query.pageable.page <= 0) {
             return;
         }
         this.query.pageable.page--;

--- a/app/ui/src/invoice/overview/invoice-overview.ts
+++ b/app/ui/src/invoice/overview/invoice-overview.ts
@@ -117,6 +117,22 @@ export class InvoiceOverview {
         this.reloadCurrentView();
     }
 
+    get pageStart() {
+        const total = this.invoiceContext.invoicePage?.totalElements ?? 0;
+        if (!total) {
+            return 0;
+        }
+        return (this.invoiceContext.invoicePage.page * this.invoiceContext.invoicePage.size) + 1;
+    }
+
+    get pageEnd() {
+        const total = this.invoiceContext.invoicePage?.totalElements ?? 0;
+        if (!total) {
+            return 0;
+        }
+        return Math.min((this.invoiceContext.invoicePage.page + 1) * this.invoiceContext.invoicePage.size, total);
+    }
+
     toggleSort(property: string) {
         const currentDirection = this.sortDirection(property);
         const direction: SortDirection = currentDirection === 'asc' ? 'desc' : 'asc';

--- a/app/ui/src/login/reset-password.html
+++ b/app/ui/src/login/reset-password.html
@@ -1,22 +1,14 @@
 <import from="../components/view/wizard-view"></import>
+<import from="../components/choose-password/choose-password"></import>
 
 <wizard-view>
     <h1 au-slot="header" t="reset.title">Reset Password</h1>
     <form class="auth-form" submit.trigger="resetPassword()">
         <p t="reset.enter-email">Enter your e-mail address to reset your password.</p>
-        <div class="grid">
-            <label class="field full">
-                <span t="label.password">Password</span>
-                <input name="new-password" type="password" required value.bind="password" />
-            </label>
-            <label class="field full">
-                <span t="label.confirm-password">Password</span>
-                <input name="new-password" type="password" required value.bind="confirmPassword" />
-            </label>
-        </div>
+        <choose-password component.ref="choosePassword" password.two-way="password" confirm-password.two-way="confirmPassword"></choose-password>
         <p if.bind="error" class="form-error" t="reset.reset-failed">Reset password failed</p>
         <div class="auth-actions">
-            <button type="submit" class="btn primary" disabled.bind="!password || password !== confirmPassword || password.length < 8" t="reset.action">Reset Password</button>
+            <button type="submit" class="btn primary" disabled.bind="!password || !choosePassword || !choosePassword.rules.matchOk || !choosePassword.rules.pwStrong" t="reset.action">Reset Password</button>
         </div>
     </form>
 </wizard-view>

--- a/app/ui/src/login/reset-password.ts
+++ b/app/ui/src/login/reset-password.ts
@@ -1,6 +1,7 @@
 import {Params, RouteNode, Router} from "@aurelia/router";
 import {resolve} from "@aurelia/kernel";
 import {PasswordService, ResetPasswordRequest} from "../services/kyc/password-service";
+import {ChoosePassword} from "../components/choose-password/choose-password";
 
 export class ResetPassword {
     readonly passwordService = resolve(PasswordService);
@@ -9,12 +10,16 @@ export class ResetPassword {
     token: string;
     password: string;
     confirmPassword: string;
+    choosePassword: ChoosePassword;
 
     public loading(params: Params, next: RouteNode) {
         this.token = next.queryParams.get('token');
     }
 
     async resetPassword() {
+        if (!this.choosePassword?.rules.pwStrong || !this.choosePassword?.rules.matchOk) {
+            return;
+        }
         const request = {
             token: this.token,
             newPassword: this.password,

--- a/app/ui/src/partner/partner-overview.html
+++ b/app/ui/src/partner/partner-overview.html
@@ -1,5 +1,3 @@
-<import from="../app/value-converters/date-format.ts"></import>
-
 <div class="invoices-layout">
     <aside class="mailbox">
         <div class="mailbox-title" t="partner.title">Partners</div>
@@ -113,7 +111,7 @@
                         </tbody>
                     </table>
                 </div>
-                <div if.bind="!partnerContext.filteredPartners || partnerContext.filteredPartners.length === 0" class="empty-state" >
+                <div if.bind="visiblePartnerCount === 0" class="empty-state" >
                     <div class="empty-icon" aria-hidden="true">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                             <path d="M7 3h7l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
@@ -122,10 +120,10 @@
                     </div>
                     <p t="partner.empty">No partners match your filters.</p>
                 </div>
-                <div class="table-footer pager" hidden>
-                    <button type="button" class="btn ghost" t="common.previous">← Previous</button>
-                    <span class="pager-range"></span>
-                    <button type="button" class="btn ghost" t="common.next">Next →</button>
+                <div class="table-footer pager" if.bind="visiblePartnerCount > 0">
+                    <button type="button" class="btn ghost" click.trigger="previousPage()" disabled.bind="currentPage <= 0" t="common.previous">Previous</button>
+                    <span class="pager-range">${pageStart} - ${pageEnd} / ${visiblePartnerCount}</span>
+                    <button type="button" class="btn ghost" click.trigger="nextPage()" disabled.bind="currentPage >= totalPages - 1" t="common.next">Next</button>
                 </div>
             </div>
         </div>

--- a/app/ui/src/partner/partner-overview.html
+++ b/app/ui/src/partner/partner-overview.html
@@ -4,15 +4,15 @@
         <nav>
             <button active.class="category === 'all'" class="mail-item" click.trigger="filterItems('all')">
                 <span class="label" t="partner.all">All</span>
-                <span class="badge">0</span>
+                <span class="badge">${allCount}</span>
             </button>
             <button active.class="category === 'customers'" class="mail-item" click.trigger="filterItems('customers')">
                 <span class="label" t="partner.customers">Customers</span>
-                <span class="badge">0</span>
+                <span class="badge">${customerCount}</span>
             </button>
             <button active.class="category === 'suppliers'" class="mail-item" click.trigger="filterItems('suppliers')">
                 <span class="label" t="partner.suppliers">Suppliers</span>
-                <span class="badge">0</span>
+                <span class="badge">${supplierCount}</span>
             </button>
         </nav>
     </aside>

--- a/app/ui/src/partner/partner-overview.html
+++ b/app/ui/src/partner/partner-overview.html
@@ -53,17 +53,47 @@
                         <thead>
                         <tr>
                             <th t="partner.table.type">Type</th>
-                            <th t="partner.table.name">Name</th>
-                            <th t="partner.table.address">Address</th>
-                            <th t="partner.table.postal-code">Postal code</th>
-                            <th t="partner.table.city">City</th>
-                            <th t="partner.table.country">Country</th>
-                            <th t="partner.table.vat">VAT</th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('name')">
+                                    <span t="partner.table.name">Name</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='name'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('address')">
+                                    <span t="partner.table.address">Address</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='address'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('postalCode')">
+                                    <span t="partner.table.postal-code">Postal code</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='postalCode'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('city')">
+                                    <span t="partner.table.city">City</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='city'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('countryCode')">
+                                    <span t="partner.table.country">Country</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='countryCode'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('vatNumber')">
+                                    <span t="partner.table.vat">VAT</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='vatNumber'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
                             <th class="actions-col" t="partner.table.actions">Actions</th>
                         </tr>
                         </thead>
                         <tbody>
-                        <tr repeat.for="item of partnerContext.filteredPartners.filter(p => p.name.toLowerCase().includes(searchQuery.toLowerCase()))" click.trigger="selectItem(item)">
+                        <tr repeat.for="item of visiblePartners" click.trigger="selectItem(item)">
                             <td>
                                 <span if.bind="item.customer" class="pill sent" t="partner.edit.customer">C</span>
                                 <span if.bind="item.supplier" class="pill incoming" t="partner.edit.supplier">S</span>

--- a/app/ui/src/partner/partner-overview.ts
+++ b/app/ui/src/partner/partner-overview.ts
@@ -18,6 +18,9 @@ export class PartnerOverview {
     activeSortDirection: SortDirection = 'asc';
     pageSize = 20;
     currentPage = 0;
+    allCount = 0;
+    customerCount = 0;
+    supplierCount = 0;
 
     attached() {
         this.loadPartners();
@@ -25,6 +28,7 @@ export class PartnerOverview {
 
     @watch((vm) => vm.partnerContext.partners.length)
     partnersChange() {
+        this.updateCounts();
         this.filterItems(this.category);
     }
 
@@ -34,6 +38,7 @@ export class PartnerOverview {
 
     async loadPartners() {
         this.partnerContext.partners = await this.partnerService.getPartners();
+        this.updateCounts();
     }
 
     filterItems(category) {
@@ -117,6 +122,7 @@ export class PartnerOverview {
         try {
             await this.partnerService.deletePartner(partner.id)
             this.partnerContext.deletePartner(partner);
+            this.updateCounts();
             this.ea.publish('alert', {alertType: AlertType.Success, text: this.i18n.tr('alert.partner.deleted')});
         } catch (e) {
             console.log(e);
@@ -154,5 +160,12 @@ export class PartnerOverview {
             default:
                 return '';
         }
+    }
+
+    private updateCounts() {
+        const partners = this.partnerContext.partners ?? [];
+        this.allCount = partners.length;
+        this.customerCount = partners.filter(partner => partner.customer).length;
+        this.supplierCount = partners.filter(partner => partner.supplier).length;
     }
 }

--- a/app/ui/src/partner/partner-overview.ts
+++ b/app/ui/src/partner/partner-overview.ts
@@ -16,6 +16,8 @@ export class PartnerOverview {
     category = 'all';
     activeSortProperty = 'name';
     activeSortDirection: SortDirection = 'asc';
+    pageSize = 20;
+    currentPage = 0;
 
     attached() {
         this.loadPartners();
@@ -26,12 +28,17 @@ export class PartnerOverview {
         this.filterItems(this.category);
     }
 
+    searchQueryChanged() {
+        this.currentPage = 0;
+    }
+
     async loadPartners() {
         this.partnerContext.partners = await this.partnerService.getPartners();
     }
 
     filterItems(category) {
         this.category = category;
+        this.currentPage = 0;
         switch (category) {
             case 'all':
                 this.partnerContext.filteredPartners = this.partnerContext.partners;
@@ -46,6 +53,30 @@ export class PartnerOverview {
     }
 
     get visiblePartners() {
+        const start = this.currentPage * this.pageSize;
+        return this.sortedFilteredPartners.slice(start, start + this.pageSize);
+    }
+
+    get visiblePartnerCount() {
+        return this.sortedFilteredPartners.length;
+    }
+
+    get totalPages() {
+        return Math.max(1, Math.ceil(this.visiblePartnerCount / this.pageSize));
+    }
+
+    get pageStart() {
+        if (!this.visiblePartnerCount) {
+            return 0;
+        }
+        return (this.currentPage * this.pageSize) + 1;
+    }
+
+    get pageEnd() {
+        return Math.min((this.currentPage + 1) * this.pageSize, this.visiblePartnerCount);
+    }
+
+    get sortedFilteredPartners() {
         const query = this.searchQuery.toLowerCase();
         const filtered = (this.partnerContext.filteredPartners ?? [])
             .filter(partner => partner.name.toLowerCase().includes(query));
@@ -60,6 +91,21 @@ export class PartnerOverview {
             this.activeSortProperty = property;
             this.activeSortDirection = 'asc';
         }
+        this.currentPage = 0;
+    }
+
+    nextPage() {
+        if (this.currentPage >= this.totalPages - 1) {
+            return;
+        }
+        this.currentPage++;
+    }
+
+    previousPage() {
+        if (this.currentPage <= 0) {
+            return;
+        }
+        this.currentPage--;
     }
 
     selectItem(partner: PartnerDto) {

--- a/app/ui/src/partner/partner-overview.ts
+++ b/app/ui/src/partner/partner-overview.ts
@@ -5,13 +5,17 @@ import {IEventAggregator, watch} from "aurelia";
 import {AlertType} from "../components/alert/alert";
 import {I18N} from "@aurelia/i18n";
 
+type SortDirection = "asc" | "desc";
+
 export class PartnerOverview {
     private readonly ea: IEventAggregator = resolve(IEventAggregator);
     private partnerContext = resolve(PartnerContext);
     private partnerService = resolve(PartnerService);
     private readonly i18n = resolve(I18N);
     searchQuery = '';
-    category = 'all'
+    category = 'all';
+    activeSortProperty = 'name';
+    activeSortDirection: SortDirection = 'asc';
 
     attached() {
         this.loadPartners();
@@ -41,6 +45,23 @@ export class PartnerOverview {
         }
     }
 
+    get visiblePartners() {
+        const query = this.searchQuery.toLowerCase();
+        const filtered = (this.partnerContext.filteredPartners ?? [])
+            .filter(partner => partner.name.toLowerCase().includes(query));
+
+        return [...filtered].sort((a, b) => this.comparePartners(a, b));
+    }
+
+    toggleSort(property: string) {
+        if (this.activeSortProperty === property) {
+            this.activeSortDirection = this.activeSortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            this.activeSortProperty = property;
+            this.activeSortDirection = 'asc';
+        }
+    }
+
     selectItem(partner: PartnerDto) {
         this.partnerContext.selectedPartner = partner;
     }
@@ -56,5 +77,36 @@ export class PartnerOverview {
             this.ea.publish('alert', {alertType: AlertType.Danger, text: this.i18n.tr('alert.partner.delete-failed')});
         }
         return false;
+    }
+
+    private comparePartners(a: PartnerDto, b: PartnerDto) {
+        const left = this.partnerValue(a, this.activeSortProperty);
+        const right = this.partnerValue(b, this.activeSortProperty);
+        const direction = this.activeSortDirection === 'asc' ? 1 : -1;
+
+        if (typeof left === 'number' && typeof right === 'number') {
+            return (left - right) * direction;
+        }
+
+        return String(left ?? '').localeCompare(String(right ?? ''), undefined, {numeric: true, sensitivity: 'base'}) * direction;
+    }
+
+    private partnerValue(partner: PartnerDto, property: string) {
+        switch (property) {
+            case 'name':
+                return partner.name;
+            case 'address':
+                return `${partner.registeredOffice?.street ?? ''} ${partner.registeredOffice?.houseNumber ?? ''}`.trim();
+            case 'postalCode':
+                return partner.registeredOffice?.postalCode;
+            case 'city':
+                return partner.registeredOffice?.city;
+            case 'countryCode':
+                return partner.registeredOffice?.countryCode;
+            case 'vatNumber':
+                return partner.vatNumber;
+            default:
+                return '';
+        }
     }
 }

--- a/app/ui/src/product/product-category-modal.html
+++ b/app/ui/src/product/product-category-modal.html
@@ -1,6 +1,6 @@
 <div class="modal" role="dialog" aria-modal="true" show.bind="open">
     <div class="modal-backdrop"></div>
-    <div class="modal-card">
+    <div class="modal-card" keydown.trigger="onKeyDown($event)">
         <header class="modal-header">
             <h2 t="product.categoryModal.title">Product Category</h2>
             <button class="icon-btn" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close" click.trigger="closeModal()">×</button>
@@ -19,7 +19,7 @@
             <footer class="modal-footer">
                 <button type="button" class="btn danger" click.trigger="deleteProductCategory()" style="margin-right: auto" t="common.delete">Delete</button>
                 <button type="button" class="btn" click.trigger="closeModal()" t="common.cancel">Cancel</button>
-                <button type="button" class="btn primary" click.trigger="saveProductCategory()" t="common.confirm">Confirm</button>
+                <button type="button" class="btn primary" click.trigger="saveProductCategory()" disabled.bind="!category.name || !category.name.trim()" t="common.confirm">Confirm</button>
             </footer>
         </div>
     </div>

--- a/app/ui/src/product/product-category-modal.ts
+++ b/app/ui/src/product/product-category-modal.ts
@@ -27,6 +27,9 @@ export class ProductCategoryModal {
     }
 
     async saveProductCategory() {
+        if (!this.category?.name?.trim()) {
+            return;
+        }
         if (this.productCategoryToUpdate) {
             const productCategory = await this.productCategoryService.updateProductCategory(this.category.id, this.category);
             this.productCategoryToUpdate.name = productCategory.name;
@@ -44,5 +47,21 @@ export class ProductCategoryModal {
         this.productContext.deleteProductCategory(this.category);
         this.open = false;
         this.signaler.dispatchSignal('productUpdate');
+    }
+
+    onKeyDown(event: KeyboardEvent) {
+        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
+            return;
+        }
+        event.preventDefault();
+        this.saveProductCategory();
+    }
+
+    private shouldIgnoreEnter(target: EventTarget | null) {
+        const element = target as HTMLElement | null;
+        if (!element) {
+            return false;
+        }
+        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
     }
 }

--- a/app/ui/src/product/product-category-modal.ts
+++ b/app/ui/src/product/product-category-modal.ts
@@ -2,6 +2,7 @@ import {ProductCategoryDto, ProductCategoryService} from "../services/app/produc
 import {resolve} from "@aurelia/kernel";
 import {ProductContext} from "./product-context";
 import {ISignaler} from "aurelia";
+import {onModalEnter} from "../components/util/modal-keyboard";
 
 export class ProductCategoryModal {
     private readonly signaler = resolve(ISignaler);
@@ -50,18 +51,6 @@ export class ProductCategoryModal {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== 'Enter' || this.shouldIgnoreEnter(event.target)) {
-            return;
-        }
-        event.preventDefault();
-        this.saveProductCategory();
-    }
-
-    private shouldIgnoreEnter(target: EventTarget | null) {
-        const element = target as HTMLElement | null;
-        if (!element) {
-            return false;
-        }
-        return ['BUTTON', 'A', 'TEXTAREA'].includes(element.tagName);
+        onModalEnter(event, () => this.saveProductCategory());
     }
 }

--- a/app/ui/src/product/product-overview.html
+++ b/app/ui/src/product/product-overview.html
@@ -54,20 +54,65 @@
                     <table class="data-table" aria-describedby="invoices-title">
                         <thead>
                         <tr>
-                            <th t="product.table.name">Name</th>
-                            <th t="product.table.description">Description</th>
-                            <th t="product.table.category">Category</th>
-                            <th t="product.table.reference">Reference</th>
-                            <th t="product.table.barcode">Barcode</th>
-                            <th t="product.table.cost-price">Cost Price</th>
-                            <th t="product.table.sale-price">Sale Price</th>
-                            <th t="product.table.tax-percentage">Tax Percentage</th>
-                            <th t="product.table.stock-quantity">Stock Quantity</th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('name')">
+                                    <span t="product.table.name">Name</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='name'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('description')">
+                                    <span t="product.table.description">Description</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='description'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('category')">
+                                    <span t="product.table.category">Category</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='category'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('reference')">
+                                    <span t="product.table.reference">Reference</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='reference'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('barcode')">
+                                    <span t="product.table.barcode">Barcode</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='barcode'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('costPrice')">
+                                    <span t="product.table.cost-price">Cost Price</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='costPrice'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('salePrice')">
+                                    <span t="product.table.sale-price">Sale Price</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='salePrice'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('taxPercentage')">
+                                    <span t="product.table.tax-percentage">Tax Percentage</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='taxPercentage'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th>
+                                <button type="button" class="sort-button" click.trigger="toggleSort('stockQuantity')">
+                                    <span t="product.table.stock-quantity">Stock Quantity</span>
+                                    <span class="sort-indicator ${activeSortProperty!=='stockQuantity'?'is-idle':activeSortDirection==='asc'?'is-asc':'is-desc'}" aria-hidden="true"></span>
+                                </button>
+                            </th>
                             <th class="actions-col" t="product.table.actions">Actions</th>
                         </tr>
                         </thead>
                         <tbody>
-                        <tr repeat.for="item of productContext.products.filter(p => p.name.toLowerCase().includes(searchQuery.toLowerCase()) && (productContext.selectedProductCategory === undefined || productContext.selectedProductCategory.id === p.categoryId))" click.trigger="selectItem(item)">
+                        <tr repeat.for="item of visibleProducts" click.trigger="selectItem(item)">
                             <td>${item.name}</td>
                             <td>${item.description}</td>
                             <td><span color.style="productContext.productCategoryMap.get(asNum(item.categoryId)).color">${productContext.productCategoryMap.get(asNum(item.categoryId)).name & signal:'productUpdate'}</span></td>

--- a/app/ui/src/product/product-overview.html
+++ b/app/ui/src/product/product-overview.html
@@ -118,8 +118,8 @@
                             <td><span color.style="productContext.productCategoryMap.get(asNum(item.categoryId)).color">${productContext.productCategoryMap.get(asNum(item.categoryId)).name & signal:'productUpdate'}</span></td>
                             <td>${item.reference}</td>
                             <td>${item.barcode}</td>
-                            <td>${item.costPrice}</td>
-                            <td>${item.salePrice}</td>
+                            <td>${item.costPrice | price:'EUR'}</td>
+                            <td>${item.salePrice | price:'EUR'}</td>
                             <td>${item.taxPercentage}</td>
                             <td>${item.stockQuantity}</td>
                             <td class="actions-col">
@@ -131,7 +131,7 @@
                         </tbody>
                     </table>
                 </div>
-                <div if.bind="!productContext.products || productContext.products.length === 0" class="empty-state" >
+                <div if.bind="visibleProductCount === 0" class="empty-state" >
                     <div class="empty-icon" aria-hidden="true">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                             <path d="M7 3h7l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
@@ -139,6 +139,11 @@
                         </svg>
                     </div>
                     <p t="product.empty">No products match your filters.</p>
+                </div>
+                <div class="table-footer pager" if.bind="visibleProductCount > 0">
+                    <button type="button" class="btn ghost" click.trigger="previousPage()" disabled.bind="currentPage <= 0" t="common.previous">Previous</button>
+                    <span class="pager-range">${pageStart} - ${pageEnd} / ${visibleProductCount}</span>
+                    <button type="button" class="btn ghost" click.trigger="nextPage()" disabled.bind="currentPage >= totalPages - 1" t="common.next">Next</button>
                 </div>
             </div>
         </div>

--- a/app/ui/src/product/product-overview.ts
+++ b/app/ui/src/product/product-overview.ts
@@ -7,6 +7,8 @@ import {ProductCategoryDto, ProductCategoryService} from "../services/app/produc
 import {ProductCategoryModal} from "./product-category-modal";
 import {I18N} from "@aurelia/i18n";
 
+type SortDirection = "asc" | "desc";
+
 export class ProductOverview {
     private readonly ea: IEventAggregator = resolve(IEventAggregator);
     private productContext = resolve(ProductContext);
@@ -15,6 +17,8 @@ export class ProductOverview {
     private readonly i18n = resolve(I18N);
     @bindable productCategoryModal: ProductCategoryModal;
     searchQuery = '';
+    activeSortProperty = 'name';
+    activeSortDirection: SortDirection = 'asc';
 
     attached() {
         this.loadProductsAndCategories();
@@ -26,6 +30,16 @@ export class ProductOverview {
             this.productContext.productCategoryMap.set(value.id, value);
         });
         this.productContext.products = await this.productService.getProducts();
+    }
+
+    get visibleProducts() {
+        const query = this.searchQuery.toLowerCase();
+        const filtered = this.productContext.products.filter(p =>
+            p.name.toLowerCase().includes(query)
+            && (this.productContext.selectedProductCategory === undefined || this.productContext.selectedProductCategory.id === p.categoryId)
+        );
+
+        return [...filtered].sort((a, b) => this.compareProducts(a, b));
     }
 
     selectItem(product: ProductDto) {
@@ -49,6 +63,15 @@ export class ProductOverview {
         this.productContext.selectedProductCategory = category;
     }
 
+    toggleSort(property: string) {
+        if (this.activeSortProperty === property) {
+            this.activeSortDirection = this.activeSortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            this.activeSortProperty = property;
+            this.activeSortDirection = 'asc';
+        }
+    }
+
     newProductCategory() {
         this.productCategoryModal.showModal(undefined);
     }
@@ -62,5 +85,42 @@ export class ProductOverview {
             return item;
         }
         return parseInt(item);
+    }
+
+    private compareProducts(a: ProductDto, b: ProductDto) {
+        const left = this.productValue(a, this.activeSortProperty);
+        const right = this.productValue(b, this.activeSortProperty);
+        const direction = this.activeSortDirection === 'asc' ? 1 : -1;
+
+        if (typeof left === 'number' && typeof right === 'number') {
+            return (left - right) * direction;
+        }
+
+        return String(left ?? '').localeCompare(String(right ?? ''), undefined, {numeric: true, sensitivity: 'base'}) * direction;
+    }
+
+    private productValue(product: ProductDto, property: string) {
+        switch (property) {
+            case 'name':
+                return product.name;
+            case 'description':
+                return product.description;
+            case 'category':
+                return this.productContext.productCategoryMap.get(this.asNum(product.categoryId))?.name;
+            case 'reference':
+                return product.reference;
+            case 'barcode':
+                return product.barcode;
+            case 'costPrice':
+                return product.costPrice ?? 0;
+            case 'salePrice':
+                return product.salePrice ?? 0;
+            case 'taxPercentage':
+                return product.taxPercentage ?? 0;
+            case 'stockQuantity':
+                return product.stockQuantity ?? 0;
+            default:
+                return '';
+        }
     }
 }

--- a/app/ui/src/product/product-overview.ts
+++ b/app/ui/src/product/product-overview.ts
@@ -19,6 +19,8 @@ export class ProductOverview {
     searchQuery = '';
     activeSortProperty = 'name';
     activeSortDirection: SortDirection = 'asc';
+    pageSize = 20;
+    currentPage = 0;
 
     attached() {
         this.loadProductsAndCategories();
@@ -33,8 +35,32 @@ export class ProductOverview {
     }
 
     get visibleProducts() {
+        const start = this.currentPage * this.pageSize;
+        return this.sortedFilteredProducts.slice(start, start + this.pageSize);
+    }
+
+    get visibleProductCount() {
+        return this.sortedFilteredProducts.length;
+    }
+
+    get totalPages() {
+        return Math.max(1, Math.ceil(this.visibleProductCount / this.pageSize));
+    }
+
+    get pageStart() {
+        if (!this.visibleProductCount) {
+            return 0;
+        }
+        return (this.currentPage * this.pageSize) + 1;
+    }
+
+    get pageEnd() {
+        return Math.min((this.currentPage + 1) * this.pageSize, this.visibleProductCount);
+    }
+
+    get sortedFilteredProducts() {
         const query = this.searchQuery.toLowerCase();
-        const filtered = this.productContext.products.filter(p =>
+        const filtered = (this.productContext.products ?? []).filter(p =>
             p.name.toLowerCase().includes(query)
             && (this.productContext.selectedProductCategory === undefined || this.productContext.selectedProductCategory.id === p.categoryId)
         );
@@ -61,6 +87,7 @@ export class ProductOverview {
 
     filterItems(category: ProductCategoryDto | undefined) {
         this.productContext.selectedProductCategory = category;
+        this.currentPage = 0;
     }
 
     toggleSort(property: string) {
@@ -70,6 +97,25 @@ export class ProductOverview {
             this.activeSortProperty = property;
             this.activeSortDirection = 'asc';
         }
+        this.currentPage = 0;
+    }
+
+    searchQueryChanged() {
+        this.currentPage = 0;
+    }
+
+    nextPage() {
+        if (this.currentPage >= this.totalPages - 1) {
+            return;
+        }
+        this.currentPage++;
+    }
+
+    previousPage() {
+        if (this.currentPage <= 0) {
+            return;
+        }
+        this.currentPage--;
     }
 
     newProductCategory() {

--- a/app/ui/src/registration/email-confirmation.html
+++ b/app/ui/src/registration/email-confirmation.html
@@ -1,6 +1,7 @@
 <import from="../components/view/wizard-view"></import>
 <import from="../components/stepper/stepper"></import>
 <import from="../components/eid/card-reader"></import>
+<import from="../components/choose-password/choose-password"></import>
 
 <wizard-view>
     <stepper if.bind="step !== 3" au-slot="stepper" steps.bind="[1,2,3,4,5]" completed-steps.bind="step+2"></stepper>
@@ -98,26 +99,7 @@
                 </div>
 
                 <div style="width: 100%" show.bind="agreedToContract">
-                    <h3 t="confirmation.choose-credentials-title">2. Choose Credentials</h3>
-                    <div class="grid single">
-                        <label class="field full">
-                            <span t="label.password">Password</span>
-                            <input name="password" type="password" value.bind="password"/>
-                        </label>
-                        <label class="field full">
-                            <span t="label.confirm-password">Confirm password</span>
-                            <input name="password" type="password" value.bind="passwordDuplicate"/>
-                        </label>
-                    </div>
-                    <ul class="pw-hints" if.bind="password">
-                        <li class.bind="lengthOk?'ok':''">At least 12 characters</li>
-                        <li class.bind="lowerOk?'ok':''">At least 1 lower</li>
-                        <li class.bind="upperOk?'ok':''">At least 1 UPPER</li>
-                        <li class.bind="numberOk?'ok':''">At least 1 number</li>
-                        <li class.bind="symbolOk?'ok':''">At least 1 symbol</li>
-                        <li class.bind="matchOk?'ok':''">Passwords match</li>
-                    </ul>
-                    <meter min="0" max="8" low="4" high="7" optimum="8" value.bind="pwScore" aria-label="Password strength"></meter>
+                    <choose-password component.ref="choosePassword" password.two-way="password" confirm-password.two-way="passwordDuplicate" show-heading.bind="true"></choose-password>
                 </div>
 
                 <div class="vertical-separator" show.bind="agreedToContract"></div>
@@ -128,7 +110,7 @@
                 </div>
                 <div show.bind="agreedToContract">
                     <div class="auth-actions" style="margin-top: 15px">
-                        <button type="button" class="btn primary" disabled.bind="!pwStrong || !password || password !== passwordDuplicate || !agreedToContract || confirmInProgress" click.trigger="confirmContract()" t="confirmation.sign-button">
+                        <button type="button" class="btn primary" disabled.bind="!choosePassword || !choosePassword.rules.pwStrong || !password || !choosePassword.rules.matchOk || !agreedToContract || confirmInProgress" click.trigger="confirmContract()" t="confirmation.sign-button">
                             Sign
                         </button>
                     </div>

--- a/app/ui/src/registration/email-confirmation.ts
+++ b/app/ui/src/registration/email-confirmation.ts
@@ -14,6 +14,7 @@ import {PeppolDirectoryResponse, PeppolDirService} from "../services/peppol/pepp
 import {SignatureAlgorithm} from "@web-eid/web-eid-library/models/SignatureAlgorithm";
 import {LibrarySignResponse} from "@web-eid/web-eid-library/models/message/LibraryResponse";
 import {I18N} from "@aurelia/i18n";
+import {ChoosePassword} from "../components/choose-password/choose-password";
 
 export class EmailConfirmation {
     readonly ea: IEventAggregator = resolve(IEventAggregator);
@@ -36,6 +37,7 @@ export class EmailConfirmation {
     private confirmInProgress = false;
     private warningKey;
     private alreadyRegisteredProvider = '';
+    private choosePassword: ChoosePassword;
 
     public loading(params: Params, next: RouteNode) {
         this.emailToken = next.queryParams.get('token');
@@ -55,36 +57,6 @@ export class EmailConfirmation {
     getContractUrl() {
         const contractUrl = this.registrationService.getContractUrl(this.confirmedDirector.id, this.emailToken);
         return `${contractUrl}#page=1&view=FitH,300`;
-    }
-
-    get lengthOk(): boolean { return this.password.length >= 12; }
-
-    get lowerOk(): boolean {
-        return (/[a-z]/.test(this.password));
-    }
-
-    get upperOk(): boolean {
-        return (/[A-Z]/.test(this.password));
-    }
-
-    get numberOk(): boolean {
-        return (/\d/.test(this.password));
-    }
-
-    get symbolOk(): boolean {
-        return (/[^A-Za-z0-9]/.test(this.password));
-    }
-
-    get matchOk(): boolean {
-        return !!this.password && this.password === this.passwordDuplicate;
-    }
-
-    get pwScore(): number {
-        return this.password ? Math.min(4, Math.floor(this.password.length / 4)) + (this.lowerOk ? 1 : 0) + (this.upperOk ? 1 : 0) + (this.numberOk ? 1 : 0) + (this.symbolOk ? 1 : 0) : 0;
-    }
-
-    get pwStrong() {
-        return this.lengthOk && this.lowerOk && this.upperOk && this.numberOk && this.symbolOk;
     }
 
     public async checkPeppolDirectory(peppolId: string) {

--- a/app/ui/src/services/app/login-service.ts
+++ b/app/ui/src/services/app/login-service.ts
@@ -60,7 +60,7 @@ export class LoginService {
 
     async getJwtToken(username: string, password: string) {
         const authHeaders: Headers = new Headers;
-        authHeaders.append('Authorization', `Basic ${btoa(`${username}:${password}`)}` );
+        authHeaders.append('Authorization', `Basic ${this.toBase64Utf8(`${username}:${password}`)}` );
         const requestInit: RequestInit = { headers: authHeaders }
         const response = await this.kycApi.httpClient.post(`/api/jwt/auth`, undefined, requestInit);
         return await response.text();
@@ -84,5 +84,14 @@ export class LoginService {
         this.partnerService.clearCache();
         this.sponsorService.clearCache();
         this.statisticsService.clearCache();
+    }
+
+    private toBase64Utf8(value: string) {
+        const bytes = new TextEncoder().encode(value);
+        let binary = '';
+        for (const byte of bytes) {
+            binary += String.fromCharCode(byte);
+        }
+        return btoa(binary);
     }
 }

--- a/app/ui/src/services/peppol/ubl.ts
+++ b/app/ui/src/services/peppol/ubl.ts
@@ -29,6 +29,23 @@ export function getAmount(line: UBLLine): Quantity {
     }
 }
 
+/**
+ * Ensures a line has a valid, non-negative numeric unit price, defaulting missing or
+ * invalid values to 0. Mutates the line in place and returns the normalized unit price.
+ */
+export function normalizeLinePrice(line: UBLLine): number {
+    if (!line.Price) {
+        line.Price = { PriceAmount: { value: 0 } } as UBLLine["Price"];
+    }
+    if (!line.Price.PriceAmount) {
+        line.Price.PriceAmount = { value: 0 };
+    }
+    const rawUnitPrice = Number(line.Price.PriceAmount.value);
+    const unitPrice = Number.isFinite(rawUnitPrice) && rawUnitPrice >= 0 ? rawUnitPrice : 0;
+    line.Price.PriceAmount.value = unitPrice;
+    return unitPrice;
+}
+
 export interface InvoiceLine extends UBLBaseLine {
     InvoicedQuantity?: Quantity;
 }

--- a/proxy/src/main/java/org/letspeppol/proxy/controller/AppController.java
+++ b/proxy/src/main/java/org/letspeppol/proxy/controller/AppController.java
@@ -99,7 +99,7 @@ public class AppController {
         return ResponseEntity.status(HttpStatus.OK).body(ublDocumentSenderService.update(id, ublDocumentDto, noArchive));
     }
 
-    @PutMapping("{id}/send")
+    @PutMapping("{id}/reschedule")
     public ResponseEntity<UblDocumentDto> reschedule(@AuthenticationPrincipal Jwt jwt,
                                                      @PathVariable UUID id,
                                                      @RequestBody UblDocumentDto ublDocumentDto,


### PR DESCRIPTION
- [ ] Modals are located over the footer, allowing confirm button on smaller screens
- [ ] Previous button on invoices list works
- [ ] Added paging to partners and products
- [ ] Invoice, partner and product list can be sorted
- [ ] Stock quantity can be used
- [ ] Password set/reset is uniform over 3 possible flows (i.e. registration, forgot password and change password in Account)
- [ ] Login works with non-Latin1 characters (e.g. €) 
- [ ] Partners have the correct numbers
- [ ] Peppol ID added to Account page
- [ ] Upload UBL flow accepts correct VAT codes (skips the frontend validation process and relies on Helger Validator in backend)
- [ ] Unit price in invoice is sanitized to 0 if wrong or empty values are stored