### PR TITLE
Exclude errored invoices from open invoice status (#269)

### DIFF
--- a/app/backend/src/main/java/org/letspeppol/app/controller/DocumentController.java
+++ b/app/backend/src/main/java/org/letspeppol/app/controller/DocumentController.java
@@ -138,6 +138,12 @@ public class DocumentController {
         return documentService.paid(peppolId, id);
     }
 
+    @PutMapping("{id}/error-seen")
+    public DocumentDto markErrorSeen(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID id) {
+        String peppolId = JwtUtil.getPeppolId(jwt);
+        return documentService.markErrorSeen(peppolId, id);
+    }
+
     @DeleteMapping("{id}")
     public void delete(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID id) {
         String peppolId = JwtUtil.getPeppolId(jwt);

--- a/app/backend/src/main/java/org/letspeppol/app/dto/DocumentDto.java
+++ b/app/backend/src/main/java/org/letspeppol/app/dto/DocumentDto.java
@@ -20,6 +20,7 @@ public record DocumentDto(
         Instant draftedOn,
         Instant readOn,
         Instant paidOn,
+        Instant errorSeenOn,
         String partnerName,
         String invoiceReference,
         DocumentType type,

--- a/app/backend/src/main/java/org/letspeppol/app/dto/TotalsDto.java
+++ b/app/backend/src/main/java/org/letspeppol/app/dto/TotalsDto.java
@@ -2,7 +2,7 @@ package org.letspeppol.app.dto;
 
 import java.math.BigDecimal;
 
-public record TotalsDto(DirectionTotals inclVat, DirectionTotals exclVat) {
+public record TotalsDto(DirectionTotals inclVat, DirectionTotals exclVat, long erroredUnseenCount) {
 
     public record DirectionTotals(
             BigDecimal payableOpen,

--- a/app/backend/src/main/java/org/letspeppol/app/dto/TotalsRow.java
+++ b/app/backend/src/main/java/org/letspeppol/app/dto/TotalsRow.java
@@ -15,7 +15,8 @@ public record TotalsRow(
         BigDecimal totalPayableThisYearExclVat,
         BigDecimal totalReceivableOpenExclVat,
         BigDecimal totalReceivableOverdueExclVat,
-        BigDecimal totalReceivableThisYearExclVat
+        BigDecimal totalReceivableThisYearExclVat,
+        long erroredUnseenCount
 ) {
 
     public TotalsDto.DirectionTotals inclVat() {
@@ -39,6 +40,6 @@ public record TotalsRow(
     }
 
     public TotalsDto toDto() {
-        return new TotalsDto(inclVat(), exclVat());
+        return new TotalsDto(inclVat(), exclVat(), erroredUnseenCount);
     }
 }

--- a/app/backend/src/main/java/org/letspeppol/app/mapper/DocumentMapper.java
+++ b/app/backend/src/main/java/org/letspeppol/app/mapper/DocumentMapper.java
@@ -22,6 +22,7 @@ public class DocumentMapper {
                 document.getDraftedOn(),
                 document.getReadOn(),
                 document.getPaidOn(),
+                document.getErrorSeenOn(),
                 document.getPartnerName(),
                 document.getInvoiceReference(),
                 document.getType(),

--- a/app/backend/src/main/java/org/letspeppol/app/model/Document.java
+++ b/app/backend/src/main/java/org/letspeppol/app/model/Document.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Currency;
 import java.util.UUID;
+import static org.hibernate.type.SqlTypes.LONGVARCHAR;
 import static org.hibernate.type.SqlTypes.VARCHAR;
 
 @Entity
@@ -48,7 +49,7 @@ public class Document implements Persistable<UUID> {
 
     private String processedStatus; //Useful for feedback from Peppol AP
 
-    @Lob
+    @JdbcTypeCode(LONGVARCHAR) //Map to the PG `text` column as a plain string; @Lob would make Hibernate treat it as a large object (OID) and fail to read text content
     private String ubl; //Can be left empty once processed as owner owns the data, i.e. no-archive is enabled and downloadCount > 1, the other field are sufficient to keep the proxy fully operational
 
     ///INTERNAL INFORMATION
@@ -65,6 +66,8 @@ public class Document implements Persistable<UUID> {
     private Instant readOn; //Useful for keeping track of read status, flagged by user
 
     private Instant paidOn; //Useful for keeping track of paid status, flagged by user
+
+    private Instant errorSeenOn; //Useful for keeping track when an errored document was acknowledged ("seen") by the user, null is not yet acknowledged
 
 // TODO    private Instant accountantOn; //Useful for keeping track of accountant status, action executed by user, send to company.accountantEmail or null when not send yet/successful
 

--- a/app/backend/src/main/java/org/letspeppol/app/model/EmailJob.java
+++ b/app/backend/src/main/java/org/letspeppol/app/model/EmailJob.java
@@ -23,7 +23,8 @@ public class EmailJob extends GenericEntity {
     }
 
     public enum Template {
-        DOCUMENT_NOTIFICATION
+        DOCUMENT_NOTIFICATION,
+        DOCUMENT_ERROR
     }
 
     @Enumerated(EnumType.STRING)

--- a/app/backend/src/main/java/org/letspeppol/app/repository/DocumentRepository.java
+++ b/app/backend/src/main/java/org/letspeppol/app/repository/DocumentRepository.java
@@ -27,26 +27,30 @@ public interface DocumentRepository extends JpaRepository<Document, UUID>, JpaSp
         """)
     boolean existsByInvoiceReferenceAndTypeAndOwnerPeppolId(String invoiceReference, DocumentType type, String ownerPeppolId);
 
+    // Errored documents (processed_status IS NOT NULL) are excluded from the money totals and counted separately as erroredUnseenCount.
     @Query(value = """
     SELECT
-      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND paid_on IS NULL THEN signed_incl END), 0) AS totalPayableOpenInclVat,
-      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND paid_on IS NULL AND due_date < NOW() THEN signed_incl END), 0) AS totalPayableOverdueInclVat,
-      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_incl END), 0) AS totalPayableThisYearInclVat,
-      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND paid_on IS NULL THEN signed_incl END), 0) AS totalReceivableOpenInclVat,
-      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND paid_on IS NULL AND due_date < NOW() THEN signed_incl END), 0) AS totalReceivableOverdueInclVat,
-      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_incl END), 0) AS totalReceivableThisYearInclVat,
-      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND paid_on IS NULL THEN signed_excl END), 0) AS totalPayableOpenExclVat,
-      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND paid_on IS NULL AND due_date < NOW() THEN signed_excl END), 0) AS totalPayableOverdueExclVat,
-      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_excl END), 0) AS totalPayableThisYearExclVat,
-      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND paid_on IS NULL THEN signed_excl END), 0) AS totalReceivableOpenExclVat,
-      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND paid_on IS NULL AND due_date < NOW() THEN signed_excl END), 0) AS totalReceivableOverdueExclVat,
-      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_excl END), 0) AS totalReceivableThisYearExclVat
+      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND processed_status IS NULL AND paid_on IS NULL THEN signed_incl END), 0) AS totalPayableOpenInclVat,
+      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND processed_status IS NULL AND paid_on IS NULL AND due_date < NOW() THEN signed_incl END), 0) AS totalPayableOverdueInclVat,
+      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND processed_status IS NULL AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_incl END), 0) AS totalPayableThisYearInclVat,
+      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND paid_on IS NULL THEN signed_incl END), 0) AS totalReceivableOpenInclVat,
+      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND paid_on IS NULL AND due_date < NOW() THEN signed_incl END), 0) AS totalReceivableOverdueInclVat,
+      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_incl END), 0) AS totalReceivableThisYearInclVat,
+      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND processed_status IS NULL AND paid_on IS NULL THEN signed_excl END), 0) AS totalPayableOpenExclVat,
+      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND processed_status IS NULL AND paid_on IS NULL AND due_date < NOW() THEN signed_excl END), 0) AS totalPayableOverdueExclVat,
+      COALESCE(SUM(CASE WHEN direction = 'INCOMING' AND processed_status IS NULL AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_excl END), 0) AS totalPayableThisYearExclVat,
+      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND paid_on IS NULL THEN signed_excl END), 0) AS totalReceivableOpenExclVat,
+      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND paid_on IS NULL AND due_date < NOW() THEN signed_excl END), 0) AS totalReceivableOverdueExclVat,
+      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_excl END), 0) AS totalReceivableThisYearExclVat,
+      COALESCE(SUM(CASE WHEN processed_status IS NOT NULL AND error_seen_on IS NULL THEN 1 ELSE 0 END), 0) AS erroredUnseenCount
     FROM (
       SELECT
         direction,
         paid_on,
         due_date,
         issue_date,
+        processed_status,
+        error_seen_on,
         CASE WHEN type = 'CREDIT_NOTE' THEN -amount_incl_vat ELSE amount_incl_vat END AS signed_incl,
         CASE WHEN type = 'CREDIT_NOTE' THEN -amount_excl_vat ELSE amount_excl_vat END AS signed_excl
       FROM app.document

--- a/app/backend/src/main/java/org/letspeppol/app/repository/DocumentRepository.java
+++ b/app/backend/src/main/java/org/letspeppol/app/repository/DocumentRepository.java
@@ -42,7 +42,7 @@ public interface DocumentRepository extends JpaRepository<Document, UUID>, JpaSp
       COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND paid_on IS NULL THEN signed_excl END), 0) AS totalReceivableOpenExclVat,
       COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND paid_on IS NULL AND due_date < NOW() THEN signed_excl END), 0) AS totalReceivableOverdueExclVat,
       COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NULL AND issue_date >= date_trunc('year', NOW()) AND issue_date < date_trunc('year', NOW()) + INTERVAL '1 year' THEN signed_excl END), 0) AS totalReceivableThisYearExclVat,
-      COALESCE(SUM(CASE WHEN processed_status IS NOT NULL AND error_seen_on IS NULL THEN 1 ELSE 0 END), 0) AS erroredUnseenCount
+      COALESCE(SUM(CASE WHEN direction = 'OUTGOING' AND processed_status IS NOT NULL AND error_seen_on IS NULL THEN 1 ELSE 0 END), 0) AS erroredUnseenCount
     FROM (
       SELECT
         direction,

--- a/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
+++ b/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
@@ -432,7 +432,9 @@ public class DocumentService {
     private void notifyIfNewlyErrored(Document document, String previousProcessedStatus) {
         if (previousProcessedStatus == null && document.getProcessedStatus() != null) {
             Company company = document.getCompany();
-            if (company != null && company.isEnableEmailNotification()) {
+            // A failed outgoing document is important enough to always notify, independently of
+            // enableEmailNotification (which only governs incoming-document notifications).
+            if (company != null) {
                 notificationService.notifyDocumentError(company, document);
             }
         }

--- a/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
+++ b/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
@@ -261,11 +261,13 @@ public class DocumentService {
 
     public void updateStatus(UblDocumentDto ublDocumentDto) {
         Document document = documentRepository.findById(ublDocumentDto.id()).orElseThrow(() -> new NotFoundException("Document does not exist"));
+        String previousProcessedStatus = document.getProcessedStatus();
         document.setProxyOn(ublDocumentDto.createdOn());
         document.setScheduledOn(ublDocumentDto.scheduledOn());
         document.setProcessedOn(ublDocumentDto.processedOn());
         document.setProcessedStatus(ublDocumentDto.processedStatus());
         documentRepository.save(document);
+        notifyIfNewlyErrored(document, previousProcessedStatus);
     }
 
     public DocumentDto send(String peppolId, UUID id, Instant schedule, String tokenValue) {
@@ -327,11 +329,28 @@ public class DocumentService {
         return DocumentMapper.toDto(document);
     }
 
+    public DocumentDto markErrorSeen(String peppolId, UUID id) {
+        Document document = documentRepository.findById(id).orElseThrow(() -> new NotFoundException("Document does not exist"));
+        if (!peppolId.equals(document.getOwnerPeppolId())) {
+            throw new SecurityException(AppErrorCodes.PEPPOL_ID_MISMATCH);
+        }
+        if (document.getProcessedStatus() == null) {
+            throw new ConflictException("Document is not errored"); //Only errored documents can be acknowledged
+        }
+        if (document.getErrorSeenOn() != null) {
+            return DocumentMapper.toDto(document); //One-way: keep the original acknowledgement timestamp
+        }
+        document.setErrorSeenOn(Instant.now());
+        document = documentRepository.save(document);
+        return DocumentMapper.toDto(document);
+    }
+
     public void delete(String peppolId, UUID id) { //TODO : do we need to send boundaries ?
         documentRepository.deleteByIdAndOwnerPeppolId(id, peppolId);
     }
 
     private Document deliver(Document document, String tokenValue) { //TODO : use boolean noArchive from Company
+        String previousProcessedStatus = document.getProcessedStatus();
         UblDocumentDto ublDocumentDto = ((document.getProxyOn() == null) ? proxyWebClient.post().uri("/sapi/document") : proxyWebClient.put().uri("/sapi/document/"+document.getId()))
                 .headers(headers -> headers.setBearerAuth(tokenValue))
                 .contentType(MediaType.APPLICATION_JSON)
@@ -367,10 +386,13 @@ public class DocumentService {
             document.getCompany().setLastInvoiceReference(document.getInvoiceReference());
         }
 
-        return documentRepository.save(document);
+        document = documentRepository.save(document);
+        notifyIfNewlyErrored(document, previousProcessedStatus);
+        return document;
     }
 
     private Document rescheduleAtProxy(Document document, String tokenValue) { //TODO : use boolean noArchive from Company
+        String previousProcessedStatus = document.getProcessedStatus();
         UblDocumentDto ublDocumentDto = proxyWebClient.put()
                 .uri("/sapi/document/" + document.getId() + "/reschedule")
                 .headers(headers -> headers.setBearerAuth(tokenValue))
@@ -401,7 +423,19 @@ public class DocumentService {
         } else {
             document.getCompany().setLastInvoiceReference(document.getInvoiceReference());
         }
-        return documentRepository.save(document);
+        document = documentRepository.save(document);
+        notifyIfNewlyErrored(document, previousProcessedStatus);
+        return document;
+    }
+
+    //Notify only on the null -> non-null transition; processedStatus is persisted, so repeated proxy syncs never re-send.
+    private void notifyIfNewlyErrored(Document document, String previousProcessedStatus) {
+        if (previousProcessedStatus == null && document.getProcessedStatus() != null) {
+            Company company = document.getCompany();
+            if (company != null && company.isEnableEmailNotification()) {
+                notificationService.notifyDocumentError(company, document);
+            }
+        }
     }
 
     @Scheduled(cron = "0 0 * * * *")

--- a/app/backend/src/main/java/org/letspeppol/app/service/NotificationService.java
+++ b/app/backend/src/main/java/org/letspeppol/app/service/NotificationService.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.HtmlUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -22,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -32,6 +34,8 @@ public class NotificationService {
     private final String notificationMailFrom;
     private final Resource emailNotificationTemplate;
     private final Resource emailNotificationHtmlTemplate;
+    private final Resource emailErrorTemplate;
+    private final Resource emailErrorHtmlTemplate;
     private final EmailJobRepository emailJobRepository;
     private final ObjectMapper objectMapper;
     private final ApplicationEventPublisher eventPublisher;
@@ -42,6 +46,8 @@ public class NotificationService {
     public NotificationService(@Value("${notification.mail.from}") String notificationMailFrom,
                                @Value("classpath:mail/notification-email_en.txt") Resource emailNotificationTemplate,
                                @Value("classpath:mail/notification-email_en.html") Resource emailNotificationHtmlTemplate,
+                               @Value("classpath:mail/error-notification-email_en.txt") Resource emailErrorTemplate,
+                               @Value("classpath:mail/error-notification-email_en.html") Resource emailErrorHtmlTemplate,
                                EmailJobRepository emailJobRepository,
                                ObjectMapper objectMapper,
                                ApplicationEventPublisher eventPublisher,
@@ -49,6 +55,8 @@ public class NotificationService {
         this.notificationMailFrom = notificationMailFrom;
         this.emailNotificationTemplate = emailNotificationTemplate;
         this.emailNotificationHtmlTemplate = emailNotificationHtmlTemplate;
+        this.emailErrorTemplate = emailErrorTemplate;
+        this.emailErrorHtmlTemplate = emailErrorHtmlTemplate;
         this.emailJobRepository = emailJobRepository;
         this.objectMapper = objectMapper;
         this.eventPublisher = eventPublisher;
@@ -113,6 +121,76 @@ public class NotificationService {
         } catch (Exception e) {
             log.error("Unable to create email notification");
         }
+    }
+
+    /** Notify the company that one of its outgoing invoices was rejected by the Peppol AP. */
+    public void notifyDocumentError(Company company, Document document) {
+        try {
+            SponsorProperties.Sponsor sponsor = nextSponsor();
+
+            // Untrusted (UBL/AP) values: null-coalesced, substituted last, and HTML-escaped in the HTML body (see replaceExternalPlaceholders).
+            String partner = Objects.toString(document.getPartnerName(), "");
+            String reference = Objects.toString(document.getInvoiceReference(), "");
+            String errorMessage = Objects.toString(document.getProcessedStatus(), "");
+
+            String text = getTemplateContents("en-error-txt", emailErrorTemplate)
+                    .replace("{{uuid}}", document.getId().toString());
+
+            String html = null;
+            if (sponsor != null) {
+                String logoUrl = sponsorProperties.getBaseUrl() + sponsor.getLogo();
+                text = text
+                        .replace("{{supportedByText}}", sponsorProperties.getEmailText())
+                        .replace("{{sponsorName}}", sponsor.getName())
+                        .replace("{{sponsorUrl}}", sponsor.getUrl());
+
+                html = getTemplateContents("en-error-html", emailErrorHtmlTemplate)
+                        .replace("{{uuid}}", document.getId().toString())
+                        .replace("{{supportedByText}}", sponsorProperties.getEmailText())
+                        .replace("{{sponsorName}}", sponsor.getName())
+                        .replace("{{sponsorUrl}}", sponsor.getUrl())
+                        .replace("{{sponsorLogoUrl}}", logoUrl);
+                html = replaceExternalPlaceholders(html, partner, reference, errorMessage, true);
+            } else {
+                // No sponsors configured — strip the placeholder lines from plain text
+                text = text
+                        .replace("\n--\n{{supportedByText}}: {{sponsorName}} ({{sponsorUrl}})\n", "");
+            }
+            text = replaceExternalPlaceholders(text, partner, reference, errorMessage, false);
+
+            DocumentNotificationEmailDto emailDto = new DocumentNotificationEmailDto(
+                    notificationMailFrom,
+                    company.getSubscriberEmail(),
+                    company.getEmailNotificationCcList(),
+                    null,
+                    null,
+                    "Invoice %s could not be delivered".formatted(reference),
+                    text,
+                    html,
+                    null //No attachment: the document failed to be delivered
+            );
+
+            String json = objectMapper.writeValueAsString(emailDto);
+            EmailJob emailJob = EmailJob.builder()
+                    .template(EmailJob.Template.DOCUMENT_ERROR)
+                    .toAddress(company.getSubscriberEmail())
+                    .payload(json)
+                    .build();
+            EmailJob saved = emailJobRepository.save(emailJob);
+            eventPublisher.publishEvent(new EmailJobCreatedEvent(saved.getId()));
+        } catch (JsonProcessingException e) {
+            log.error("Failed to convert error email object to json");
+        } catch (Exception e) {
+            log.error("Unable to create error email notification for document {}", document.getId(), e);
+        }
+    }
+
+    /** Substitutes the externally-influenced placeholders last; HTML-escapes them when {@code escape} is true. */
+    private String replaceExternalPlaceholders(String content, String partner, String reference, String errorMessage, boolean escape) {
+        return content
+                .replace("{{partner}}", escape ? HtmlUtils.htmlEscape(partner) : partner)
+                .replace("{{reference}}", escape ? HtmlUtils.htmlEscape(reference) : reference)
+                .replace("{{errorMessage}}", escape ? HtmlUtils.htmlEscape(errorMessage) : errorMessage);
     }
 
     private SponsorProperties.Sponsor nextSponsor() {

--- a/app/backend/src/main/resources/db/migration/V1.13__document_error_seen_on.sql
+++ b/app/backend/src/main/resources/db/migration/V1.13__document_error_seen_on.sql
@@ -1,0 +1,1 @@
+ALTER TABLE document ADD COLUMN error_seen_on timestamp with time zone;

--- a/app/backend/src/main/resources/mail/error-notification-email_en.html
+++ b/app/backend/src/main/resources/mail/error-notification-email_en.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<body style="font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: 0 auto;">
+  <p>Hello,</p>
+
+  <p>
+    Your invoice with reference <strong>{{reference}}</strong> for <strong>{{partner}}</strong>
+    could not be delivered over the Peppol network.
+  </p>
+
+  <p style="color: #b3261e;">
+    Reason: <strong>{{errorMessage}}</strong>
+  </p>
+
+  <p>
+    Please review and correct the invoice, then resend it from your dashboard:
+    <a href="https://be.letspeppol.org/invoices/{{uuid}}">https://be.letspeppol.org/invoices/{{uuid}}</a>
+  </p>
+
+  <p>Kind regards,<br>Let’s Peppol Team</p>
+  <a href="https://letspeppol.org" target="_blank">
+    <img src="https://letspeppol.org/logo.png" alt="Let’s Peppol" style="max-height: 48px; max-width: 200px; margin-top: 8px;">
+  </a>
+
+  <hr style="border: none; border-top: 1px solid #eee; margin: 24px 0;">
+
+  <p style="font-size: 12px; color: #888; margin-bottom: 8px;">{{supportedByText}}</p>
+  <a href="{{sponsorUrl}}" target="_blank">
+    <img src="{{sponsorLogoUrl}}" alt="{{sponsorName}}" style="max-height: 48px; max-width: 200px;">
+  </a>
+</body>
+</html>

--- a/app/backend/src/main/resources/mail/error-notification-email_en.txt
+++ b/app/backend/src/main/resources/mail/error-notification-email_en.txt
@@ -1,0 +1,13 @@
+Hello,
+
+Your invoice with reference {{reference}} for {{partner}} could not be delivered over the Peppol network.
+Reason: {{errorMessage}}
+
+Please review and correct the invoice, then resend it from your dashboard:
+https://be.letspeppol.org/invoices/{{uuid}}
+
+Kind regards,
+Let’s Peppol Team
+
+--
+{{supportedByText}}: {{sponsorName}} ({{sponsorUrl}})

--- a/app/backend/src/test/java/org/letspeppol/app/repository/DocumentRepositoryTotalsTest.java
+++ b/app/backend/src/test/java/org/letspeppol/app/repository/DocumentRepositoryTotalsTest.java
@@ -593,4 +593,73 @@ class DocumentRepositoryTotalsTest extends PostgresIntegrationTest {
         // 500 + 123.45 + 200 - 45 - 10 = 768.45  (drafted + last-year excluded)
         assertThat(totals.totalReceivableThisYearInclVat()).isEqualByComparingTo("768.45");
     }
+
+    @Test
+    void erroredInvoicesAreExcludedFromAllMoneyTotals() {
+        // Issue #269: a valid pending outgoing invoice still counts in open/overdue/this-year
+        persist(d -> {
+            d.setDirection(DocumentDirection.OUTGOING);
+            d.setAmountInclVat(new BigDecimal("50.00"));
+            d.setDueDate(daysAgo(5));
+        });
+        // Errored outgoing invoice (processedStatus set): excluded everywhere even though unpaid, non-draft, overdue, this year
+        persist(d -> {
+            d.setDirection(DocumentDirection.OUTGOING);
+            d.setAmountInclVat(new BigDecimal("65.00"));
+            d.setDueDate(daysAgo(5));
+            d.setProcessedStatus("BUSINESS_ERROR: rejected by recipient AP");
+        });
+        // Errored incoming invoice: excluded from payable totals too
+        persist(d -> {
+            d.setDirection(DocumentDirection.INCOMING);
+            d.setAmountInclVat(new BigDecimal("77.00"));
+            d.setDueDate(daysAgo(5));
+            d.setProcessedStatus("BUSINESS_ERROR");
+        });
+        flush();
+
+        TotalsRow totals = documentRepository.totalsByOwner(OWNER);
+
+        assertThat(totals.totalReceivableOpenInclVat()).isEqualByComparingTo("50.00");
+        assertThat(totals.totalReceivableOverdueInclVat()).isEqualByComparingTo("50.00");
+        assertThat(totals.totalReceivableThisYearInclVat()).isEqualByComparingTo("50.00");
+        assertThat(totals.totalPayableOpenInclVat()).isEqualByComparingTo("0");
+        assertThat(totals.totalPayableOverdueInclVat()).isEqualByComparingTo("0");
+    }
+
+    @Test
+    void erroredUnseenCountCountsOnlyUnacknowledgedErroredDocuments() {
+        // Errored, not yet acknowledged -> counted
+        persist(d -> {
+            d.setDirection(DocumentDirection.OUTGOING);
+            d.setProcessedStatus("ERR-A");
+        });
+        persist(d -> {
+            d.setDirection(DocumentDirection.OUTGOING);
+            d.setProcessedStatus("ERR-B");
+        });
+        // Errored but acknowledged (errorSeenOn set) -> NOT counted
+        persist(d -> {
+            d.setDirection(DocumentDirection.OUTGOING);
+            d.setProcessedStatus("ERR-C");
+            d.setErrorSeenOn(Instant.now());
+        });
+        // Valid document (no processedStatus) -> NOT counted
+        persist(d -> d.setDirection(DocumentDirection.OUTGOING));
+        // Drafted errored document -> excluded by the drafted_on IS NULL subquery filter
+        persist(d -> {
+            d.setDirection(DocumentDirection.OUTGOING);
+            d.setProcessedStatus("ERR-D");
+            d.setDraftedOn(Instant.now());
+        });
+        // Other owner's errored document -> isolated
+        persistOther(d -> {
+            d.setDirection(DocumentDirection.OUTGOING);
+            d.setProcessedStatus("ERR-OTHER");
+        });
+        flush();
+
+        assertThat(documentRepository.totalsByOwner(OWNER).erroredUnseenCount()).isEqualTo(2L);
+        assertThat(documentRepository.totalsByOwner(OTHER_OWNER).erroredUnseenCount()).isEqualTo(1L);
+    }
 }

--- a/app/backend/src/test/java/org/letspeppol/app/repository/DocumentRepositoryTotalsTest.java
+++ b/app/backend/src/test/java/org/letspeppol/app/repository/DocumentRepositoryTotalsTest.java
@@ -652,6 +652,11 @@ class DocumentRepositoryTotalsTest extends PostgresIntegrationTest {
             d.setProcessedStatus("ERR-D");
             d.setDraftedOn(Instant.now());
         });
+        // Incoming document carrying a status is not an outgoing send error -> NOT counted (#270 review)
+        persist(d -> {
+            d.setDirection(DocumentDirection.INCOMING);
+            d.setProcessedStatus("ERR-INCOMING");
+        });
         // Other owner's errored document -> isolated
         persistOther(d -> {
             d.setDirection(DocumentDirection.OUTGOING);

--- a/app/ui/src/app/lets-peppol.css
+++ b/app/ui/src/app/lets-peppol.css
@@ -935,6 +935,31 @@ main.container .data-table tbody td {
     color: var(--status-overdue)
 }
 
+/* Dashboard errored-invoices indicator */
+.kpi-error-card {
+    display: flex;
+    align-items: center;
+    gap: var(--space-04);
+    margin-bottom: var(--space-04);
+    border-color: var(--pill-error-border);
+    background: var(--pill-error-bg);
+    color: var(--pill-error-fg);
+}
+
+.kpi-error-count {
+    font-size: 1.4rem;
+    font-weight: 700;
+}
+
+/* Acknowledged ("seen") errored invoice, greyed out */
+.data-table tbody tr.row-seen {
+    opacity: .55;
+}
+
+.data-table tbody tr.row-seen .pill.error {
+    filter: grayscale(1);
+}
+
 /* ============================================================================
    10. Row Actions & Empty States
    ============================================================================ */

--- a/app/ui/src/app/locale/translation_de.json
+++ b/app/ui/src/app/locale/translation_de.json
@@ -258,7 +258,8 @@
     "vat-suffix": {
       "incl": "inkl. MwSt.",
       "excl": "exkl. MwSt."
-    }
+    },
+    "errored": "Fehlerhafte Rechnungen"
   },
   "navigation": {
     "dashboard": "Dashboard",
@@ -362,6 +363,12 @@
         "CREDIT_NOTE": "Gutschrift als unbezahlt markiert"
       },
       "paid-status-failed": "Zahlungsstatus konnte nicht geändert werden",
+      "marked-seen": "Rechnung als gesehen markiert",
+      "mark-seen-failed": "Rechnung konnte nicht als gesehen markiert werden",
+      "resend-failed": {
+        "INVOICE": "Wiederverwenden der Rechnung fehlgeschlagen",
+        "CREDIT_NOTE": "Wiederverwenden der Gutschrift fehlgeschlagen"
+      },
       "no-ubl-data": "Keine UBL-Daten verfügbar"
     },
     "iban": {
@@ -496,6 +503,11 @@
       "mark-unpaid": {
         "INVOICE": "Rechnung als unbezahlt markieren",
         "CREDIT_NOTE": "Gutschrift als unbezahlt markieren"
+      },
+      "mark-seen": "Als gesehen markieren",
+      "resend": {
+        "INVOICE": "Rechnung wiederverwenden und erneut senden",
+        "CREDIT_NOTE": "Gutschrift wiederverwenden und erneut senden"
       }
     },
     "table": {

--- a/app/ui/src/app/locale/translation_en.json
+++ b/app/ui/src/app/locale/translation_en.json
@@ -206,7 +206,8 @@
     "vat-suffix": {
       "incl": "incl. VAT",
       "excl": "excl. VAT"
-    }
+    },
+    "errored": "Errored invoices"
   },
   "donations": {
     "sponsors": "tier sponsors",
@@ -362,6 +363,12 @@
         "CREDIT_NOTE": "Credit note marked as unpaid"
       },
       "paid-status-failed": "Failed to change invoice paid status",
+      "marked-seen": "Invoice marked as seen",
+      "mark-seen-failed": "Failed to mark invoice as seen",
+      "resend-failed": {
+        "INVOICE": "Failed to reuse the invoice",
+        "CREDIT_NOTE": "Failed to reuse the credit note"
+      },
       "no-ubl-data": "No UBL data available"
     },
     "iban": {
@@ -496,6 +503,11 @@
       "mark-unpaid": {
         "INVOICE": "Mark invoice as unpaid",
         "CREDIT_NOTE": "Mark credit note as unpaid"
+      },
+      "mark-seen": "Mark as seen",
+      "resend": {
+        "INVOICE": "Reuse and resend invoice",
+        "CREDIT_NOTE": "Reuse and resend credit note"
       }
     },
     "table": {

--- a/app/ui/src/app/locale/translation_fr.json
+++ b/app/ui/src/app/locale/translation_fr.json
@@ -257,7 +257,8 @@
     "vat-suffix": {
       "incl": "TVA inc.",
       "excl": "HT"
-    }
+    },
+    "errored": "Factures en erreur"
   },
   "navigation" : {
     "dashboard" : "Tableau de bord",
@@ -361,6 +362,12 @@
         "CREDIT_NOTE" : "Note de crédit marquée comme impayée"
       },
       "paid-status-failed" : "Échec du changement de statut de paiement",
+      "marked-seen" : "Facture marquée comme vue",
+      "mark-seen-failed" : "Échec du marquage de la facture comme vue",
+      "resend-failed" : {
+        "INVOICE" : "Échec de la réutilisation de la facture",
+        "CREDIT_NOTE" : "Échec de la réutilisation de la note de crédit"
+      },
       "no-ubl-data" : "Aucune donnée UBL disponible"
     },
     "iban" : {
@@ -495,6 +502,11 @@
       "mark-unpaid" : {
         "INVOICE" : "Marquer la facture comme impayée",
         "CREDIT_NOTE" : "Marquer la note de crédit comme impayée"
+      },
+      "mark-seen" : "Marquer comme vue",
+      "resend" : {
+        "INVOICE" : "Réutiliser et renvoyer la facture",
+        "CREDIT_NOTE" : "Réutiliser et renvoyer la note de crédit"
       }
     },
     "table" : {

--- a/app/ui/src/app/locale/translation_nl.json
+++ b/app/ui/src/app/locale/translation_nl.json
@@ -257,7 +257,8 @@
     "vat-suffix": {
       "incl": "incl. btw",
       "excl": "excl. btw"
-    }
+    },
+    "errored": "Facturen met fout"
   },
   "navigation" : {
     "dashboard" : "Dashboard",
@@ -361,6 +362,12 @@
         "CREDIT_NOTE" : "Creditnota gemarkeerd als onbetaald"
       },
       "paid-status-failed" : "Wijzigen van betalingsstatus mislukt",
+      "marked-seen" : "Factuur gemarkeerd als gezien",
+      "mark-seen-failed" : "Markeren van factuur als gezien mislukt",
+      "resend-failed" : {
+        "INVOICE" : "Hergebruiken van de factuur mislukt",
+        "CREDIT_NOTE" : "Hergebruiken van de creditnota mislukt"
+      },
       "no-ubl-data" : "Geen UBL-gegevens beschikbaar"
     },
     "iban" : {
@@ -495,6 +502,11 @@
       "mark-unpaid" : {
         "INVOICE" : "Factuur markeren als niet betaald",
         "CREDIT_NOTE" : "Creditnota markeren als niet betaald"
+      },
+      "mark-seen" : "Markeren als gezien",
+      "resend" : {
+        "INVOICE" : "Factuur hergebruiken en opnieuw verzenden",
+        "CREDIT_NOTE" : "Creditnota hergebruiken en opnieuw verzenden"
       }
     },
     "table" : {

--- a/app/ui/src/dashboard/dashboard.html
+++ b/app/ui/src/dashboard/dashboard.html
@@ -8,6 +8,10 @@
             <span class="vat-mode-tag" t="dashboard.vat-suffix.${vatMode}"></span>
         </h1>
     </div>
+    <div class="card kpi-error-card" if.bind="erroredCount > 0" role="alert">
+        <span class="kpi-error-count">${erroredCount}</span>
+        <span class="label" t="dashboard.errored"></span>
+    </div>
     <div class="dashboard-grid">
         <div class="card kpi-card">
             <h3 style="text-align: center">Income</h3>

--- a/app/ui/src/dashboard/dashboard.ts
+++ b/app/ui/src/dashboard/dashboard.ts
@@ -41,4 +41,8 @@ export class Dashboard {
         }
         this.activeTotals = this.vatMode === 'incl' ? this.totals.inclVat : this.totals.exclVat;
     }
+
+    get erroredCount(): number {
+        return this.totals?.erroredUnseenCount ?? 0;
+    }
 }

--- a/app/ui/src/invoice/overview/invoice-overview.html
+++ b/app/ui/src/invoice/overview/invoice-overview.html
@@ -182,10 +182,10 @@
                                     <button if.bind="!item.paidOn && !item.draftedOn" class="icon-btn success" title="Mark invoice as paid" t="[title]invoice.action.mark-paid.${item.type}" disabled.bind="!!item.processedStatus" click.trigger="markPaid($event, item)">
                                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-banknote"><rect width="20" height="12" x="2" y="6" rx="2"/><circle cx="12" cy="12" r="2"/><path d="M6 12h.01"/><path d="M18 12h.01"/></svg>
                                     </button>
-                                    <button if.bind="item.processedStatus && !item.errorSeenOn && !item.draftedOn" class="icon-btn" title="Reuse and resend" t="[title]invoice.action.resend.${item.type}" click.trigger="resendErrored($event, item)">
+                                    <button if.bind="item.direction === 'OUTGOING' && item.processedStatus && !item.errorSeenOn && !item.draftedOn" class="icon-btn" title="Reuse and resend" t="[title]invoice.action.resend.${item.type}" click.trigger="resendErrored($event, item)">
                                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rotate-cw"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg>
                                     </button>
-                                    <button if.bind="item.processedStatus && !item.errorSeenOn && !item.draftedOn" class="icon-btn" title="Mark as seen" t="[title]invoice.action.mark-seen" click.trigger="markErrorSeen($event, item)">
+                                    <button if.bind="item.direction === 'OUTGOING' && item.processedStatus && !item.errorSeenOn && !item.draftedOn" class="icon-btn" title="Mark as seen" t="[title]invoice.action.mark-seen" click.trigger="markErrorSeen($event, item)">
                                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
                                     </button>
                                 </td>

--- a/app/ui/src/invoice/overview/invoice-overview.html
+++ b/app/ui/src/invoice/overview/invoice-overview.html
@@ -155,7 +155,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                            <tr repeat.for="item of invoiceContext.invoicePage.content" click.trigger="selectItem(item)">
+                            <tr repeat.for="item of invoiceContext.invoicePage.content" click.trigger="selectItem(item)" class.bind="item.errorSeenOn ? 'row-seen' : ''">
                                 <td><span class="status-dot" class.bind="item.paidOn ? 'status-ok' : isOverdue(item) ? 'status-overdue' : 'status-open'" title.bind="item.paidOn ? 'Paid at ' + formatDate(item.paidOn) : 'Not paid'"></span></td>
                                 <td><span class="pill" class.bind="item.direction === 'INCOMING' ? 'incoming' : 'sent'" t="documentDirection.${item.direction}">${item.direction}</span></td>
                                 <td><span class="pill" class.bind="item.type === 'INVOICE' ? 'sent' : 'incoming'" t="documentType.${item.type}">${item.type}</span></td>
@@ -181,6 +181,12 @@
                                     </button>
                                     <button if.bind="!item.paidOn && !item.draftedOn" class="icon-btn success" title="Mark invoice as paid" t="[title]invoice.action.mark-paid.${item.type}" disabled.bind="!!item.processedStatus" click.trigger="markPaid($event, item)">
                                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-banknote"><rect width="20" height="12" x="2" y="6" rx="2"/><circle cx="12" cy="12" r="2"/><path d="M6 12h.01"/><path d="M18 12h.01"/></svg>
+                                    </button>
+                                    <button if.bind="item.processedStatus && !item.errorSeenOn && !item.draftedOn" class="icon-btn" title="Reuse and resend" t="[title]invoice.action.resend.${item.type}" click.trigger="resendErrored($event, item)">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rotate-cw"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg>
+                                    </button>
+                                    <button if.bind="item.processedStatus && !item.errorSeenOn && !item.draftedOn" class="icon-btn" title="Mark as seen" t="[title]invoice.action.mark-seen" click.trigger="markErrorSeen($event, item)">
+                                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-eye"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
                                     </button>
                                 </td>
                             </tr>

--- a/app/ui/src/invoice/overview/invoice-overview.ts
+++ b/app/ui/src/invoice/overview/invoice-overview.ts
@@ -184,6 +184,39 @@ export class InvoiceOverview {
         }
     }
 
+    // Acknowledge an errored invoice: it stays visible (greyed out) but leaves the errored counter and offers no further action.
+    async markErrorSeen(event: Event, item: DocumentDto) {
+        event.stopPropagation();
+        try {
+            const updated = await this.invoiceService.markErrorSeenDocument(item.id);
+            item.errorSeenOn = updated.errorSeenOn;
+            this.ea.publish('alert', {alertType: AlertType.Success, text: this.i18n.tr('alert.invoice.marked-seen')});
+        } catch (e) {
+            this.ea.publish('alert', {alertType: AlertType.Danger, text: this.i18n.tr('alert.invoice.mark-seen-failed')});
+        }
+    }
+
+    // Reuse the errored invoice's content as a new editable draft so the user can correct it and resend with the same number
+    // (the uniqueness check ignores errored documents, so the number is free to reuse).
+    async resendErrored(event: Event, item: DocumentDto) {
+        event.stopPropagation();
+        try {
+            const errored = await this.invoiceService.getDocument(item.id);
+            if (!errored.ubl) {
+                this.ea.publish('alert', {alertType: AlertType.Warning, text: this.i18n.tr('alert.invoice.no-ubl-data')});
+                return;
+            }
+            const draft = await this.invoiceService.createDocument(errored.ubl, true, false);
+            this.invoiceContext.draftPage?.content.unshift(draft);
+            if (this.invoiceContext.draftPage) {
+                this.invoiceContext.draftPage.totalElements++;
+            }
+            this.router.load(`/invoices/${draft.id}`);
+        } catch (e) {
+            this.ea.publish('alert', {alertType: AlertType.Danger, text: this.i18n.tr(`alert.invoice.resend-failed.${item.type}`)});
+        }
+    }
+
     showUploadUblModal() {
         this.uploadUblModal.showModal();
     }

--- a/app/ui/src/services/app/invoice-service.ts
+++ b/app/ui/src/services/app/invoice-service.ts
@@ -63,6 +63,7 @@ export interface DocumentDto {
     draftedOn?: string;             // ISO datetime (Instant)
     readOn?: string;                // ISO datetime (Instant)
     paidOn?: string;                // ISO datetime (Instant)
+    errorSeenOn?: string;           // ISO datetime (Instant) - errored invoice acknowledged ("seen")
     partnerName?: string;
     invoiceReference?: string;
     type?: DocumentType;
@@ -144,6 +145,10 @@ export class InvoiceService {
 
     async togglePaidDocument(id: string) : Promise<DocumentDto> {
         return await this.appApi.httpClient.put(`/sapi/document/${id}/paid`).then(response => response.json());
+    }
+
+    async markErrorSeenDocument(id: string) : Promise<DocumentDto> {
+        return await this.appApi.httpClient.put(`/sapi/document/${id}/error-seen`).then(response => response.json());
     }
 
     async deleteDocument(id: string) {

--- a/app/ui/src/services/app/statistics-service.ts
+++ b/app/ui/src/services/app/statistics-service.ts
@@ -65,6 +65,7 @@ export type DirectionTotals = {
 export type Totals = {
     inclVat: DirectionTotals;
     exclVat: DirectionTotals;
+    erroredUnseenCount: number; // count of errored, not-yet-acknowledged invoices
 };
 
 // export type DocumentQuery = {


### PR DESCRIPTION
Closes #269

Fixed: errored invoices are no longer treated as open.

- Excluded from the dashboard open / overdue / this-year totals, and surfaced separately as an "errored" indicator (count).
- They stay visible in the invoice list with two actions: **mark as seen** greys the row, leaves the errored count) and **reuse & resend** (reopens the content in the editor, same invoice number).
- An e-mail is sent to the company when a document errors.

Prerequisite bug found & fixed along the way: `Document.ubl` (a Postgres `text` column) was annotated `@Lob`, so Hibernate read it as a large object and threw `Bad value for type long: <?xml…` for any document carrying its UBL - which also broke the invoice list. Mapped it as `@JdbcTypeCode(LONGVARCHAR)` (plain text); no schema or data migration needed.

! Heads-up - same latent bug in the **proxy** module: `UblDocument.ubl` is still `@Lob`. If that column is also `text`, it will fail the same way once a document with UBL is read there. Should be tracked as its own issue/fix.

<img width="2541" height="1143" alt="2026-06-21_18h16_42" src="https://github.com/user-attachments/assets/90ce4f6e-1db2-49f0-8702-f6d1215d3c7d" />
<img width="2547" height="661" alt="2026-06-21_18h16_54" src="https://github.com/user-attachments/assets/41dea652-1bf0-40e8-a821-3f9870072fd8" />
