### PR TITLE
fix(ui): reliably return to invoice list on browser back from invoice detail (#267)

### DIFF
--- a/app/ui/src/invoice/edit/components/tiles/payment-info.html
+++ b/app/ui/src/invoice/edit/components/tiles/payment-info.html
@@ -26,23 +26,23 @@
     </template>
 
     <template if.bind="isSuccessfullyProcessed">
-        <template if.bind="invoiceContext.selectedDocument.paidOn">
+        <template if.bind="invoiceContext.selectedDocument?.paidOn">
             <span class="payment-state-note">
                 <span t="invoice.paymentQr.marked-done-on">Payment marked done on</span>
                 <b>${invoiceContext.selectedDocument.paidOn | dateFormat}</b>
             </span>
             <button type="button" class="btn payment-state-action" new-feature="payment-state-action" click.trigger="markPaid($event)">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-banknote-x-icon lucide-banknote-x"><path d="M13 18H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5"/><path d="m17 17 5 5"/><path d="M18 12h.01"/><path d="m22 17-5 5"/><path d="M6 12h.01"/><circle cx="12" cy="12" r="2"/></svg>
-                <span t="invoice.paymentQr.mark-unpaid-document.${invoiceContext.selectedDocument.type}">Mark invoice as unpaid</span>
+                <span t="invoice.paymentQr.mark-unpaid-document.${invoiceContext.selectedDocument?.type}">Mark invoice as unpaid</span>
             </button>
         </template>
-        <button if.bind="!invoiceContext.selectedDocument.paidOn && shouldShowPaymentQrAction" type="button" class="btn payment-state-action" new-feature="payment-state-action" click.trigger="showPaymentQrModal()">
+        <button if.bind="!invoiceContext.selectedDocument?.paidOn && shouldShowPaymentQrAction" type="button" class="btn payment-state-action" new-feature="payment-state-action" click.trigger="showPaymentQrModal()">
             <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-qr-code-icon lucide-qr-code"><rect width="5" height="5" x="3" y="3" rx="1"/><rect width="5" height="5" x="16" y="3" rx="1"/><rect width="5" height="5" x="3" y="16" rx="1"/><path d="M21 16h-3a2 2 0 0 0-2 2v3"/><path d="M21 21v.01"/><path d="M12 7v3a2 2 0 0 1-2 2H7"/><path d="M3 12h.01"/><path d="M12 3h.01"/><path d="M12 16v.01"/><path d="M16 12h1"/><path d="M21 12v.01"/><path d="M12 21v-1"/></svg>
             <span t="invoice.paymentQr.show-and-mark-paid">Show payment QR and mark as paid</span>
         </button>
-        <button if.bind="!invoiceContext.selectedDocument.paidOn && !shouldShowPaymentQrAction" type="button" class="btn payment-state-action" new-feature="payment-state-action" click.trigger="markPaid($event)">
+        <button if.bind="!invoiceContext.selectedDocument?.paidOn && !shouldShowPaymentQrAction" type="button" class="btn payment-state-action" new-feature="payment-state-action" click.trigger="markPaid($event)">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-banknote-arrow-down-icon lucide-banknote-arrow-down"><path d="M12 18H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5"/><path d="m16 19 3 3 3-3"/><path d="M18 12h.01"/><path d="M19 16v6"/><path d="M6 12h.01"/><circle cx="12" cy="12" r="2"/></svg>
-            <span t="invoice.paymentQr.mark-paid-document.${invoiceContext.selectedDocument.type}">Mark invoice as paid</span>
+            <span t="invoice.paymentQr.mark-paid-document.${invoiceContext.selectedDocument?.type}">Mark invoice as paid</span>
         </button>
     </template>
 </div>

--- a/app/ui/src/invoice/edit/invoice-edit.html
+++ b/app/ui/src/invoice/edit/invoice-edit.html
@@ -22,7 +22,7 @@
 <invoice-number-modal component.ref="invoiceNumberModal" invoice-context.bind="invoiceContext"></invoice-number-modal>
 <validation-result-modal component.ref="validationResultModal"></validation-result-modal>
 
-<div class="invoices-main">
+<div class="invoices-main" if.bind="invoiceContext.selectedInvoice">
     <div class="section-header">
         <div style="display:flex;align-items:center;gap:.5rem">
             <h1 if.bind="!readOnly" style="margin:0" t="invoice.new.${selectedDocumentType}">New Invoice/Credit-Note</h1>
@@ -47,7 +47,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-down-icon lucide-file-down"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 18v-6"/><path d="m9 15 3 3 3-3"/></svg>
                 <span t="invoice.edit.download-ubl">UBL</span>
             </button>
-            <button if.bind="invoiceContext.selectedDocument.id" type="button" class="btn" click.trigger="downloadPDF()">
+            <button if.bind="invoiceContext.selectedDocument?.id" type="button" class="btn" click.trigger="downloadPDF()">
                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-down-icon lucide-file-down"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 18v-6"/><path d="m9 15 3 3 3-3"/></svg>
                 <span t="invoice.edit.download-pdf">PDF</span>
             </button>
@@ -57,7 +57,7 @@
                 <span t="invoice.edit.delete-draft">Delete draft</span>
             </button>
             <button type="button" class="btn" click.trigger="returnToOverview()" t="invoice.edit.cancel">Cancel</button>
-            <button if.bind="!invoiceContext.selectedDocument.proxyOn" type="button" class="btn primary" click.trigger="verifyNumberAndSend()" disabled.bind="!isValid" t="invoice.edit.send.${selectedDocumentType}">Send invoice</button>
+            <button if.bind="!invoiceContext.selectedDocument?.proxyOn" type="button" class="btn primary" click.trigger="verifyNumberAndSend()" disabled.bind="!isValid" t="invoice.edit.send.${selectedDocumentType}">Send invoice</button>
         </div>
     </div>
 

--- a/app/ui/src/invoice/edit/invoice-edit.ts
+++ b/app/ui/src/invoice/edit/invoice-edit.ts
@@ -347,7 +347,7 @@ export class InvoiceEdit {
             && inv.AccountingCustomerParty.Party.PartyName.Name
             && inv.AccountingCustomerParty.Party.PartyTaxScheme.TaxScheme.ID
             && inv.LegalMonetaryTotal.LineExtensionAmount.value > 0
-            && this.paymentInfo.isPaymentInfoComplete;
+            && this.paymentInfo?.isPaymentInfoComplete;
     }
 
 }

--- a/app/ui/src/invoice/invoice-context.ts
+++ b/app/ui/src/invoice/invoice-context.ts
@@ -26,6 +26,7 @@ export class InvoiceContext {
     lines : undefined | InvoiceLine[] | CreditNoteLine[];
     @observable selectedInvoice:  undefined | Invoice | CreditNote;
     selectedDocument: DocumentDto;
+    selectedRouteId: string = undefined;
     selectedDocumentType: DocumentType = DocumentType.INVOICE;
     lastReference: string = undefined;
     nextReference: string = undefined;

--- a/app/ui/src/invoice/invoices.ts
+++ b/app/ui/src/invoice/invoices.ts
@@ -13,18 +13,26 @@ export class Invoices {
     private readonly i18n = resolve(I18N);
 
     detaching() {
-        this.invoiceContext.selectedInvoice = undefined;
-        this.invoiceContext.selectedDocument = undefined;
+        this.invoiceContext.clearSelectedInvoice();
     }
 
     loading(params: Params) {
-        if (params.id) {
-            this.invoiceService.getDocument(params.id).then((doc) => {
-                this.invoiceContext.selectInvoice(doc);
-            }).catch(() => this.ea.publish('alert', {alertType: AlertType.Danger, text: this.i18n.tr('alert.invoice.load-failed')}));
+        const requestedId = params.id;
+        // Track the invoice id the router is navigating to, so a late getDocument()
+        // response can't re-select an invoice after the user already navigated away.
+        this.invoiceContext.selectedRouteId = requestedId;
+        if (requestedId) {
+            this.invoiceService.getDocument(requestedId).then((doc) => {
+                if (this.invoiceContext.selectedRouteId === requestedId) {
+                    this.invoiceContext.selectInvoice(doc);
+                }
+            }).catch(() => {
+                if (this.invoiceContext.selectedRouteId === requestedId) {
+                    this.ea.publish('alert', {alertType: AlertType.Danger, text: this.i18n.tr('alert.invoice.load-failed')});
+                }
+            });
         } else {
-            this.invoiceContext.selectedInvoice = undefined;
-            this.invoiceContext.selectedDocument = undefined;
+            this.invoiceContext.clearSelectedInvoice();
             this.ea.publish('invoicesReset');
         }
     }


### PR DESCRIPTION
Closes #267.

## Problem
Using the browser's **Back** button from an invoice detail page sometimes left the user stuck on the detail page instead of returning to the invoices list.

## Cause
The list view and the detail view are the same screen, and the detail view stayed active in the background even while hidden. When navigating back, it tried to read data for an invoice that was no longer selected, which threw an error mid-render and stopped the switch back to the list. A leftover background request could also re-open the detail right after going back.

## Fix
- The detail view is now fully removed (not just hidden) when no invoice is selected, so it can no longer read missing data and crash.
- Added safety guards on the fields that were being read during the crash.
- A late data response that arrives after the user has already navigated away is now ignored.

## Testing
- `vite build` passes, with no new lint or type warnings.
- Manually (local dev): open a detail -> Back -> reliably returns to the list, with no errors in the console, including a fast Back. Creating, editing and sending invoices are unchanged.