### PR TITLE
Clickable attachment upload + explicit auto-PDF toggle (#266)

### DIFF
--- a/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
+++ b/app/backend/src/main/java/org/letspeppol/app/service/DocumentService.java
@@ -135,7 +135,10 @@ public class DocumentService {
                  throw new AppException(AppErrorCodes.INVOICE_NUMBER_ALREADY_USED);
              }
         }
-        if (!draft && company.isAddPdfToSendingInvoice()) {
+        if (!draft) {
+            // The UI's generated_invoice marker is the source of truth: addRenderedPdfToUbl only
+            // renders a PDF when that marker is present, so the per-invoice toggle wins. The
+            // company addPdfToSendingInvoice flag only controls the toggle's default in the UI.
             ublXml = ublInvoicePdfService.addRenderedPdfToUbl(ublXml, ublDto.invoiceReference());
         }
         Document document = new Document(

--- a/app/ui/src/app/locale/translation_de.json
+++ b/app/ui/src/app/locale/translation_de.json
@@ -585,6 +585,14 @@
       "no-matches": "Keine Treffer",
       "save-as-partner": "Als Partner speichern"
     },
+    "attachmentModal": {
+      "upload-file": "Datei hochladen",
+      "upload-hint": "Datei hierher ziehen oder zum Durchsuchen klicken",
+      "upload-aria": "Anhang hinzufügen: Datei hierher ziehen oder zum Durchsuchen klicken",
+      "auto-pdf": "Automatisch generiertes Rechnungs-PDF einschließen",
+      "auto-pdf-disabled": "Aktivieren Sie das automatisch generierte PDF in Ihren Kontoeinstellungen.",
+      "auto-pdf-replace": "Ein Rechnungs-PDF wird automatisch generiert. Schalten Sie es oben aus, wenn Ihre hochgeladene Datei es ersetzt."
+    },
     "productSearch": {
       "placeholder": "Name",
       "no-matches": "Keine Treffer"

--- a/app/ui/src/app/locale/translation_de.json
+++ b/app/ui/src/app/locale/translation_de.json
@@ -590,7 +590,6 @@
       "upload-hint": "Datei hierher ziehen oder zum Durchsuchen klicken",
       "upload-aria": "Anhang hinzufügen: Datei hierher ziehen oder zum Durchsuchen klicken",
       "auto-pdf": "Automatisch generiertes Rechnungs-PDF einschließen",
-      "auto-pdf-disabled": "Aktivieren Sie das automatisch generierte PDF in Ihren Kontoeinstellungen.",
       "auto-pdf-replace": "Ein Rechnungs-PDF wird automatisch generiert. Schalten Sie es oben aus, wenn Ihre hochgeladene Datei es ersetzt."
     },
     "productSearch": {

--- a/app/ui/src/app/locale/translation_en.json
+++ b/app/ui/src/app/locale/translation_en.json
@@ -585,6 +585,14 @@
       "no-matches": "No matches",
       "save-as-partner": "Save as partner"
     },
+    "attachmentModal": {
+      "upload-file": "Upload File",
+      "upload-hint": "Drag & drop or click to browse",
+      "upload-aria": "Add an attachment: drag and drop a file or click to browse",
+      "auto-pdf": "Include the auto-generated invoice PDF",
+      "auto-pdf-disabled": "Enable the auto-generated PDF in your account settings.",
+      "auto-pdf-replace": "An invoice PDF is generated automatically. Turn it off above if your uploaded file replaces it."
+    },
     "productSearch": {
       "placeholder": "name",
       "no-matches": "No matches"

--- a/app/ui/src/app/locale/translation_en.json
+++ b/app/ui/src/app/locale/translation_en.json
@@ -590,7 +590,6 @@
       "upload-hint": "Drag & drop or click to browse",
       "upload-aria": "Add an attachment: drag and drop a file or click to browse",
       "auto-pdf": "Include the auto-generated invoice PDF",
-      "auto-pdf-disabled": "Enable the auto-generated PDF in your account settings.",
       "auto-pdf-replace": "An invoice PDF is generated automatically. Turn it off above if your uploaded file replaces it."
     },
     "productSearch": {

--- a/app/ui/src/app/locale/translation_fr.json
+++ b/app/ui/src/app/locale/translation_fr.json
@@ -583,6 +583,14 @@
       "search-partner-placeholder" : "Rechercher un partenaire par nom ou numéro TVA",
       "no-matches" : "Aucun résultat"
     },
+    "attachmentModal" : {
+      "upload-file" : "Importer un fichier",
+      "upload-hint" : "Glissez-déposez ou cliquez pour parcourir",
+      "upload-aria" : "Ajouter une pièce jointe : glissez-déposez un fichier ou cliquez pour parcourir",
+      "auto-pdf" : "Inclure le PDF de facture généré automatiquement",
+      "auto-pdf-disabled" : "Activez le PDF généré automatiquement dans les paramètres de votre compte.",
+      "auto-pdf-replace" : "Un PDF de facture est généré automatiquement. Désactivez-le ci-dessus si votre fichier importé le remplace."
+    },
     "productSearch" : {
       "placeholder" : "nom",
       "no-matches" : "Aucun résultat"

--- a/app/ui/src/app/locale/translation_fr.json
+++ b/app/ui/src/app/locale/translation_fr.json
@@ -588,7 +588,6 @@
       "upload-hint" : "Glissez-déposez ou cliquez pour parcourir",
       "upload-aria" : "Ajouter une pièce jointe : glissez-déposez un fichier ou cliquez pour parcourir",
       "auto-pdf" : "Inclure le PDF de facture généré automatiquement",
-      "auto-pdf-disabled" : "Activez le PDF généré automatiquement dans les paramètres de votre compte.",
       "auto-pdf-replace" : "Un PDF de facture est généré automatiquement. Désactivez-le ci-dessus si votre fichier importé le remplace."
     },
     "productSearch" : {

--- a/app/ui/src/app/locale/translation_nl.json
+++ b/app/ui/src/app/locale/translation_nl.json
@@ -583,6 +583,14 @@
       "search-partner-placeholder" : "Zoek partner op naam of BTW-nummer",
       "no-matches" : "Geen resultaten"
     },
+    "attachmentModal" : {
+      "upload-file" : "Bestand uploaden",
+      "upload-hint" : "Sleep een bestand hierheen of klik om te bladeren",
+      "upload-aria" : "Een bijlage toevoegen: sleep een bestand hierheen of klik om te bladeren",
+      "auto-pdf" : "Voeg de automatisch gegenereerde factuur-PDF toe",
+      "auto-pdf-disabled" : "Schakel de automatisch gegenereerde PDF in via uw accountinstellingen.",
+      "auto-pdf-replace" : "Er wordt automatisch een factuur-PDF gegenereerd. Schakel deze hierboven uit als uw geüploade bestand deze vervangt."
+    },
     "productSearch" : {
       "placeholder" : "naam",
       "no-matches" : "Geen resultaten"

--- a/app/ui/src/app/locale/translation_nl.json
+++ b/app/ui/src/app/locale/translation_nl.json
@@ -588,7 +588,6 @@
       "upload-hint" : "Sleep een bestand hierheen of klik om te bladeren",
       "upload-aria" : "Een bijlage toevoegen: sleep een bestand hierheen of klik om te bladeren",
       "auto-pdf" : "Voeg de automatisch gegenereerde factuur-PDF toe",
-      "auto-pdf-disabled" : "Schakel de automatisch gegenereerde PDF in via uw accountinstellingen.",
       "auto-pdf-replace" : "Er wordt automatisch een factuur-PDF gegenereerd. Schakel deze hierboven uit als uw geüploade bestand deze vervangt."
     },
     "productSearch" : {

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.css
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.css
@@ -17,3 +17,50 @@
 .upload-wrapper.dragging {
     background-color: #2C3C6911; /* Light blue background for drag over */
 }
+
+/* The attachment upload area is a real <button> so it is keyboard- and
+   screen-reader-accessible; reset the native button look while keeping the
+   shared .upload-wrapper styling. Scoped to button so the Upload UBL modal
+   (a <div> reusing .upload-wrapper) is unaffected. */
+button.upload-wrapper {
+    width: 100%;
+    box-sizing: border-box;
+    background: transparent;
+    color: inherit;
+    font-family: inherit;
+    cursor: pointer;
+}
+
+button.upload-wrapper:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.upload-hint {
+    margin-top: var(--space-1);
+    font-size: var(--space-1);
+    font-weight: normal;
+    opacity: 0.7;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.auto-pdf-toggle {
+    margin-bottom: var(--space-05);
+}
+
+.auto-pdf-help {
+    margin: 0 0 var(--space-1);
+    font-size: var(--space-1);
+    opacity: 0.7;
+}

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.html
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.html
@@ -6,16 +6,30 @@
             <button class="icon-btn" click.trigger="closeModal()" aria-label="Close dialog" title="Close" t="[title]common.close">×</button>
         </header>
         <div class="modal-body">
-            <div class="upload-wrapper ${isDraggingFile ? 'dragging' : ''}"
+            <button type="button" class="upload-wrapper ${isDraggingFile ? 'dragging' : ''}"
                  ref="uploadWrapper"
-                 dragenter.trigger="dragEnter($event, 'file')"
+                 click.trigger="openFilePicker()"
+                 t="[aria-label]invoice.attachmentModal.upload-aria"
+                 dragenter.trigger="dragEnter($event)"
                  dragover.trigger="dragOver($event)"
-                 dragleave.trigger="dragLeave($event, 'file')"
-                 drop.trigger="dragDrop($event, 'file')"
+                 dragleave.trigger="dragLeave($event)"
+                 drop.trigger="dragDrop($event)"
             >
-                <p>Upload File</p>
+                <span t="invoice.attachmentModal.upload-file">Upload File</span>
                 <svg width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-up-icon lucide-file-up"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 12v6"/><path d="m15 15-3-3-3 3"/></svg>
-            </div>
+                <span class="upload-hint" t="invoice.attachmentModal.upload-hint">Drag &amp; drop or click to browse</span>
+            </button>
+            <input type="file" class="visually-hidden" ref="fileInput" tabindex="-1" aria-hidden="true"
+                   accept="application/pdf,image/png,image/jpeg,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.spreadsheet"
+                   change.trigger="onFileSelected()">
+            <label class="field checkbox auto-pdf-toggle">
+                <input type="checkbox" checked.to-view="includeGeneratedPdf"
+                       change.trigger="onToggleGeneratedPdf($event.target.checked)"
+                       disabled.bind="!invoiceContext.addPdfToSendingInvoice" />
+                <span t="invoice.attachmentModal.auto-pdf">Include the auto-generated invoice PDF</span>
+            </label>
+            <p class="auto-pdf-help" if.bind="!invoiceContext.addPdfToSendingInvoice" t="invoice.attachmentModal.auto-pdf-disabled">Enable the auto-generated PDF in your account settings.</p>
+            <p class="auto-pdf-help" if.bind="includeGeneratedPdf && hasUploadedPdf" t="invoice.attachmentModal.auto-pdf-replace">An invoice PDF is generated automatically. Turn it off above if your uploaded file replaces it.</p>
             <div class="table-wrapper">
                 <table class="data-table line-table">
                     <thead>
@@ -27,7 +41,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    <tr repeat.for="line of additionalDocumentReference">
+                    <tr repeat.for="line of userAttachments">
                         <template if.bind="line.Attachment.EmbeddedDocumentBinaryObject">
                             <td>File</td>
                             <td>${line.Attachment.EmbeddedDocumentBinaryObject.__filename}</td>
@@ -47,7 +61,6 @@
                     </tbody>
                 </table>
                 <button type="button" class="btn primary" click.trigger="addExternalLink()">+ <span>Add Link</span></button>
-                <button show.bind="!generatedPdfPresent" type="button" class="btn primary" click.trigger="addGeneratedPdf()">+ <span>Add Generated PDF</span></button>
             </div>
         </div>
         <footer class="modal-footer">

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.html
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.html
@@ -24,11 +24,9 @@
                    change.trigger="onFileSelected()">
             <label class="field checkbox auto-pdf-toggle">
                 <input type="checkbox" checked.to-view="includeGeneratedPdf"
-                       change.trigger="onToggleGeneratedPdf($event.target.checked)"
-                       disabled.bind="!invoiceContext.addPdfToSendingInvoice" />
+                       change.trigger="onToggleGeneratedPdf($event.target.checked)" />
                 <span t="invoice.attachmentModal.auto-pdf">Include the auto-generated invoice PDF</span>
             </label>
-            <p class="auto-pdf-help" if.bind="!invoiceContext.addPdfToSendingInvoice" t="invoice.attachmentModal.auto-pdf-disabled">Enable the auto-generated PDF in your account settings.</p>
             <p class="auto-pdf-help" if.bind="includeGeneratedPdf && hasUploadedPdf" t="invoice.attachmentModal.auto-pdf-replace">An invoice PDF is generated automatically. Turn it off above if your uploaded file replaces it.</p>
             <div class="table-wrapper">
                 <table class="data-table line-table">

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
@@ -28,10 +28,6 @@ export class InvoiceAttachmentModal {
         } else {
             this.additionalDocumentReference = [];
         }
-        if (!this.invoiceContext.addPdfToSendingInvoice) {
-            // Auto PDF is disabled account-wide: never keep a marker the backend won't render.
-            this.additionalDocumentReference = this.additionalDocumentReference.filter(item => item.ID !== GENERATED_INVOICE);
-        }
         this.includeGeneratedPdf = this.additionalDocumentReference.some(item => item.ID === GENERATED_INVOICE);
         this.refreshUserAttachments();
         this.validate();
@@ -78,11 +74,7 @@ export class InvoiceAttachmentModal {
         if (!this.validated) {
             return;
         }
-        // Defensive: if auto PDF is off account-wide, never persist a generated marker.
-        const toSave = this.invoiceContext.addPdfToSendingInvoice
-            ? this.additionalDocumentReference
-            : this.additionalDocumentReference.filter(item => item.ID !== GENERATED_INVOICE);
-        this.invoiceContext.selectedInvoice.AdditionalDocumentReference = toSave;
+        this.invoiceContext.selectedInvoice.AdditionalDocumentReference = this.additionalDocumentReference;
         this.closeModal();
     }
 

--- a/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
+++ b/app/ui/src/invoice/edit/components/modals/invoice-attachment-modal.ts
@@ -4,7 +4,7 @@ import {AdditionalDocumentReference} from "../../../../services/peppol/ubl";
 import {resolve} from "@aurelia/kernel";
 import {AlertType} from "../../../../components/alert/alert";
 import moment from "moment";
-import {InvoiceComposer} from "../../../invoice-composer";
+import {InvoiceComposer, GENERATED_INVOICE} from "../../../invoice-composer";
 import {I18N} from "@aurelia/i18n";
 
 export class InvoiceAttachmentModal {
@@ -16,8 +16,10 @@ export class InvoiceAttachmentModal {
     open = false;
     validated = false;
     isDraggingFile = false;
-    generatedPdfPresent = false;
+    includeGeneratedPdf = false;
+    userAttachments: AdditionalDocumentReference[] = [];
     uploadWrapper: HTMLElement;
+    fileInput: HTMLInputElement;
 
     showModal() {
         this.validated = false;
@@ -26,6 +28,13 @@ export class InvoiceAttachmentModal {
         } else {
             this.additionalDocumentReference = [];
         }
+        if (!this.invoiceContext.addPdfToSendingInvoice) {
+            // Auto PDF is disabled account-wide: never keep a marker the backend won't render.
+            this.additionalDocumentReference = this.additionalDocumentReference.filter(item => item.ID !== GENERATED_INVOICE);
+        }
+        this.includeGeneratedPdf = this.additionalDocumentReference.some(item => item.ID === GENERATED_INVOICE);
+        this.refreshUserAttachments();
+        this.validate();
         this.open = true;
     }
 
@@ -34,24 +43,46 @@ export class InvoiceAttachmentModal {
     }
 
     @watch((vm) => vm.additionalDocumentReference.length)
+    onAttachmentsChanged() {
+        this.validate();
+        this.refreshUserAttachments();
+    }
+
     validate() {
         this.validated = !this.additionalDocumentReference.length || this.additionalDocumentReference.filter(item => !item.ID || (item.Attachment.ExternalReference && !item.Attachment.ExternalReference.URI)).length === 0;
     }
 
-    @watch((vm) => vm.additionalDocumentReference.length)
-    checkGeneratedPdf() {
-        this.generatedPdfPresent = this.additionalDocumentReference.length && this.additionalDocumentReference.some(item => item.ID === 'generated_invoice');
+    refreshUserAttachments() {
+        // The generated invoice PDF is represented by its own toggle, not as a row.
+        this.userAttachments = this.additionalDocumentReference.filter(item => item.ID !== GENERATED_INVOICE);
     }
 
-    addGeneratedPdf() {
-        this.additionalDocumentReference.push(...this.invoiceComposer.getAdditionalDocumentReference());
+    get hasUploadedPdf(): boolean {
+        return this.additionalDocumentReference.some(item =>
+            item.ID !== GENERATED_INVOICE
+            && item.Attachment?.EmbeddedDocumentBinaryObject?.__mimeCode === 'application/pdf');
+    }
+
+    onToggleGeneratedPdf(checked: boolean) {
+        this.includeGeneratedPdf = checked;
+        if (checked) {
+            if (!this.additionalDocumentReference.some(item => item.ID === GENERATED_INVOICE)) {
+                this.additionalDocumentReference.push(...this.invoiceComposer.getAdditionalDocumentReference());
+            }
+        } else {
+            this.additionalDocumentReference = this.additionalDocumentReference.filter(item => item.ID !== GENERATED_INVOICE);
+        }
     }
 
     saveAttachments() {
         if (!this.validated) {
             return;
         }
-        this.invoiceContext.selectedInvoice.AdditionalDocumentReference = this.additionalDocumentReference;
+        // Defensive: if auto PDF is off account-wide, never persist a generated marker.
+        const toSave = this.invoiceContext.addPdfToSendingInvoice
+            ? this.additionalDocumentReference
+            : this.additionalDocumentReference.filter(item => item.ID !== GENERATED_INVOICE);
+        this.invoiceContext.selectedInvoice.AdditionalDocumentReference = toSave;
         this.closeModal();
     }
 
@@ -88,11 +119,23 @@ export class InvoiceAttachmentModal {
         }
     }
 
+    openFilePicker() {
+        this.fileInput?.click();
+    }
+
+    async onFileSelected() {
+        await this.processFile(this.fileInput.files?.[0]);
+        // Reset so selecting the same file again still fires the change event.
+        this.fileInput.value = '';
+    }
+
     async dragDrop(e: DragEvent) {
         e.preventDefault();
         this.isDraggingFile = false;
+        await this.processFile(e.dataTransfer.files?.[0]);
+    }
 
-        const file = e.dataTransfer.files[0];
+    private async processFile(file: File | undefined) {
         if (!file) return;
         if (file.size > (3 * (1024 ** 2))) {
             this.ea.publish('alert', {alertType: AlertType.Warning, text: this.i18n.tr('alert.attachment.size-too-large-3mb')});
@@ -136,9 +179,7 @@ export class InvoiceAttachmentModal {
         } catch(error) {
             console.log(error);
             this.ea.publish('alert', {alertType: AlertType.Danger, text: this.i18n.tr('alert.upload.upload-error')});
-            return false;
         }
-        return true;
     }
 
     toBase64 = (file: File): Promise<string> => new Promise((resolve, reject) => {

--- a/app/ui/src/invoice/edit/components/tiles/attachment-info.ts
+++ b/app/ui/src/invoice/edit/components/tiles/attachment-info.ts
@@ -4,6 +4,7 @@ import {resolve} from "@aurelia/kernel";
 import {InvoiceContext} from "../../../invoice-context";
 import {bindable, IEventAggregator} from "aurelia";
 import {InvoiceService} from "../../../../services/app/invoice-service";
+import {GENERATED_INVOICE} from "../../../invoice-composer";
 import {I18N} from "@aurelia/i18n";
 
 export class AttachmentInfo {
@@ -20,7 +21,7 @@ export class AttachmentInfo {
         if (attachment.EmbeddedDocumentBinaryObject) {
             let source = `data:${attachment.EmbeddedDocumentBinaryObject.__mimeCode};base64,${attachment.EmbeddedDocumentBinaryObject.value}`;
             let objectUrl: string | null = null;
-            if (additionalDocumentReference.ID === 'generated_invoice') {
+            if (additionalDocumentReference.ID === GENERATED_INVOICE) {
                 if (!this.invoiceContext.selectedDocument || !this.invoiceContext.selectedDocument.id) {
                     this.ea.publish('alert', {alertType: AlertType.Warning, text: this.i18n.tr('alert.attachment.document-not-saved')});
                     return;

--- a/app/ui/src/invoice/invoice-composer.ts
+++ b/app/ui/src/invoice/invoice-composer.ts
@@ -16,7 +16,7 @@ import {CompanyService} from "../services/app/company-service";
 import {DocumentType} from "../services/app/invoice-service";
 import {I18N} from "@aurelia/i18n";
 
-const GENERATED_INVOICE = 'generated_invoice';
+export const GENERATED_INVOICE = 'generated_invoice';
 
 @singleton()
 export class InvoiceComposer {
@@ -327,6 +327,7 @@ export class InvoiceComposer {
             BuyerReference: invoice.BuyerReference,
             OrderReference: invoice.OrderReference,
             BillingReference: billingReference,
+            AdditionalDocumentReference: invoice.AdditionalDocumentReference,
             AccountingSupplierParty: invoice.AccountingSupplierParty,
             AccountingCustomerParty: invoice.AccountingCustomerParty,
             PaymentMeans: invoice.PaymentMeans,
@@ -355,6 +356,7 @@ export class InvoiceComposer {
             DocumentCurrencyCode: "EUR",
             BuyerReference: creditNote.BuyerReference,
             OrderReference: creditNote.OrderReference,
+            AdditionalDocumentReference: creditNote.AdditionalDocumentReference,
             AccountingSupplierParty: creditNote.AccountingSupplierParty,
             AccountingCustomerParty: creditNote.AccountingCustomerParty,
             PaymentMeans: creditNote.PaymentMeans,
@@ -372,6 +374,12 @@ export class InvoiceComposer {
     }
 
     public getAdditionalDocumentReference() {
+        // Only seed the generated-PDF marker when the company opted in. The backend
+        // renders the real PDF over this marker at send time; without the opt-in it
+        // would otherwise travel as an empty placeholder.
+        if (!this.companyService.myCompany?.addPdfToSendingInvoice) {
+            return [];
+        }
         return [{
             ID: GENERATED_INVOICE,
             DocumentDescription: 'Generated Invoice PDF',


### PR DESCRIPTION
Closes #266.

## What:
- Clicking or using the keyboard on the upload area opens the file picker, in addition to drag and drop (#266).
- The auto-generated invoice PDF is now an explicit toggle instead of a deletable file row, preventing the duplicate 'two PDFs' some users hit. The toggle reflects and controls the account addPdfToSendingInvoice setting.
- Attachments are preserved when switching between invoice and credit note.
- i18n (en/nl/fr/de).

##  Test plan:
- vite build, eslint, stylelint, and 20/20 vitest all green.
- Manual: click opens the picker; keyboard (Tab + Enter/Space); drag and drop still works; toggle off -> single PDF; disabled state when the account flag is off; type switch keeps attachments.

<img width="1432" height="1000" alt="image" src="https://github.com/user-attachments/assets/e7c230d5-7b15-46db-86f1-ab1cd2953219" />
