### PR TITLE
Update database backup pipeline

### DIFF
--- a/docker/database/backup/Dockerfile
+++ b/docker/database/backup/Dockerfile
@@ -1,7 +1,9 @@
 FROM postgres:16-alpine
 
 COPY backup/backup-entrypoint.sh /usr/local/bin/backup-entrypoint.sh
+COPY backup/backup-run.sh /usr/local/bin/backup-run.sh
 
 RUN chmod 0644 /usr/local/bin/backup-entrypoint.sh
+RUN chmod 0644 /usr/local/bin/backup-run.sh
 
 CMD ["sh", "/usr/local/bin/backup-entrypoint.sh"]

--- a/docker/database/backup/backup-entrypoint.sh
+++ b/docker/database/backup/backup-entrypoint.sh
@@ -1,20 +1,7 @@
 #!/bin/sh
 set -eu
 
-shell_quote() {
-  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
-}
-
 mkdir -p "$DATA_DIR"
-{
-  printf 'export PGHOST=%s\n' "$(shell_quote "$PGHOST")"
-  printf 'export PGUSER=%s\n' "$(shell_quote "$PGUSER")"
-  printf 'export PGPASSWORD=%s\n' "$(shell_quote "$PGPASSWORD")"
-  printf 'export DB_LIST=%s\n' "$(shell_quote "$DB_LIST")"
-  printf 'export DATA_DIR=%s\n' "$(shell_quote "$DATA_DIR")"
-  printf 'export PATH=%s\n' "$(shell_quote "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")"
-  printf 'export TZ=%s\n' "$(shell_quote "$TZ")"
-} > /etc/backup.env
 
 touch "$DATA_DIR/.sync-db-dumps.trigger"
 

--- a/docker/database/backup/backup-entrypoint.sh
+++ b/docker/database/backup/backup-entrypoint.sh
@@ -1,13 +1,28 @@
 #!/bin/sh
 set -eu
 
+shell_quote() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
 mkdir -p "$DATA_DIR"
+{
+  printf 'export PGHOST=%s\n' "$(shell_quote "$PGHOST")"
+  printf 'export PGUSER=%s\n' "$(shell_quote "$PGUSER")"
+  printf 'export PGPASSWORD=%s\n' "$(shell_quote "$PGPASSWORD")"
+  printf 'export DB_LIST=%s\n' "$(shell_quote "$DB_LIST")"
+  printf 'export DATA_DIR=%s\n' "$(shell_quote "$DATA_DIR")"
+  printf 'export PATH=%s\n' "$(shell_quote "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")"
+  printf 'export TZ=%s\n' "$(shell_quote "$TZ")"
+} > /etc/backup.env
+
+touch "$DATA_DIR/.sync-db-dumps.trigger"
 
 cat > /etc/crontabs/root <<'EOF'
 SHELL=/bin/sh
 TZ=Europe/Brussels
 
-0 0,12 * * * /bin/sh -eu -c 'ts=$(date "+%Y-%m-%dT%H-%M-%S%z"); for d in $DB_LIST; do echo "[backup] preparing $d at $ts"; ls -1t "$DATA_DIR"/$d-*.dump 2>/dev/null | tail -n +2 | xargs -r rm -f --; tmp="$DATA_DIR/.$d-$ts.dump.tmp"; final="$DATA_DIR/$d-$ts.dump"; echo "[backup] dumping $d to temp file $tmp"; if pg_dump -h "$PGHOST" -U "$PGUSER" -d "$d" -F c -Z 6 -f "$tmp"; then mv "$tmp" "$final"; echo "[backup] completed $d -> $final"; else echo "[backup] FAILED $d"; rm -f "$tmp"; exit 1; fi; done'
+0 0,12 * * * /bin/sh /usr/local/bin/backup-run.sh
 EOF
 
 echo "[backup] scheduled for 00:00 and 12:00 Europe/Brussels"

--- a/docker/database/backup/backup-run.sh
+++ b/docker/database/backup/backup-run.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -eu
 
-. /etc/backup.env
-
-mkdir -p "$DATA_DIR"
-
 status=0
 ts=$(date "+%Y-%m-%dT%H-%M-%S%z")
 
@@ -15,10 +11,10 @@ for d in $DB_LIST; do
     continue
   fi
 
-  if ls "$DATA_DIR"/"$d"-*.dump >/dev/null 2>&1; then
-    echo "[backup] refusing $d: unsynced .dump exists"
-    status=1
-    continue
+  old_dumps=$(ls -1 "$DATA_DIR"/"$d"-*.dump 2>/dev/null || true)
+  if [ -n "$old_dumps" ]; then
+    echo "[backup] removing previous local dump(s) for $d"
+    rm -f -- "$DATA_DIR"/"$d"-*.dump
   fi
 
   tmp="$DATA_DIR/$d-$ts.dump.tmp"

--- a/docker/database/backup/backup-run.sh
+++ b/docker/database/backup/backup-run.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+. /etc/backup.env
+
+mkdir -p "$DATA_DIR"
+
+status=0
+ts=$(date "+%Y-%m-%dT%H-%M-%S%z")
+
+for d in $DB_LIST; do
+  if ls "$DATA_DIR"/"$d"-*.dump.tmp >/dev/null 2>&1; then
+    echo "[backup] refusing $d: stale .dump.tmp exists"
+    status=1
+    continue
+  fi
+
+  if ls "$DATA_DIR"/"$d"-*.dump >/dev/null 2>&1; then
+    echo "[backup] refusing $d: unsynced .dump exists"
+    status=1
+    continue
+  fi
+
+  tmp="$DATA_DIR/$d-$ts.dump.tmp"
+  final="$DATA_DIR/$d-$ts.dump"
+
+  echo "[backup] dumping $d to temp file $tmp"
+
+  if pg_dump \
+    -h "$PGHOST" \
+    -U "$PGUSER" \
+    -d "$d" \
+    -F c \
+    -Z 6 \
+    -f "$tmp"
+  then
+    mv "$tmp" "$final"
+    echo "[backup] completed $d -> $final"
+  else
+    echo "[backup] FAILED $d, leaving $tmp in place"
+    status=1
+  fi
+done
+
+touch "$DATA_DIR/.sync-db-dumps.trigger"
+exit "$status"


### PR DESCRIPTION
This PR updates the database backup pipeline to retain only one local backup per database.

### Changes
- A new backup is made when the previous backup was successful
- The previous backup will be removed before making a new backup
- Limit local backup retention to one backup per database