### PR TITLE
Add a local API route

### DIFF
--- a/docker/blue/docker-compose.yml
+++ b/docker/blue/docker-compose.yml
@@ -161,11 +161,17 @@ services:
       - "traefik.http.routers.blue-api.tls.certresolver=${CERT_RESOLVER_BLUE}"
 
       # Protected API router
-      - "traefik.http.routers.blue-api.rule=Host(`${ACTIVE_DOMAIN_BLUE}`) && (PathPrefix(`/proxy/sapi/`) || PathPrefix(`/app/sapi/`) || PathPrefix(`/kyc/sapi/`))"
-      - "traefik.http.routers.blue-api.entryPoints=websecure"
-      - "traefik.http.routers.blue-api.middlewares=jwt-auth,api-limit"
-      - "traefik.http.routers.blue-api.service=nginx"
-      - "traefik.http.routers.blue-api.tls.certresolver=${CERT_RESOLVER_BLUE}"
+      - "traefik.http.routers.blue-sapi.rule=Host(`${ACTIVE_DOMAIN_BLUE}`) && (PathPrefix(`/proxy/sapi/`) || PathPrefix(`/app/sapi/`) || PathPrefix(`/kyc/sapi/`))"
+      - "traefik.http.routers.blue-sapi.entryPoints=websecure"
+      - "traefik.http.routers.blue-sapi.middlewares=jwt-auth,api-limit"
+      - "traefik.http.routers.blue-sapi.service=nginx"
+      - "traefik.http.routers.blue-sapi.tls.certresolver=${CERT_RESOLVER_BLUE}"
+
+      # Local API router
+      - "traefik.http.routers.blue-lapi.rule=Host(`localhost`) && (PathPrefix(`/proxy/lapi/`) || PathPrefix(`/app/lapi/`) || PathPrefix(`/kyc/lapi/`))"
+      - "traefik.http.routers.blue-lapi.entrypoints=internal"
+      - "traefik.http.routers.blue-lapi.middlewares=api-limit"
+      - "traefik.http.routers.blue-lapi.service=nginx"
 
       # Service definition
       - "traefik.http.services.nginx.loadbalancer.server.port=80"

--- a/docker/green/docker-compose.yml
+++ b/docker/green/docker-compose.yml
@@ -167,6 +167,12 @@ services:
       - "traefik.http.routers.green-sapi.service=nginx"
       - "traefik.http.routers.green-sapi.tls.certresolver=${CERT_RESOLVER_GREEN}"
 
+      # Local API router
+      - "traefik.http.routers.green-lapi.rule=Host(`localhost`) && (PathPrefix(`/proxy/lapi/`) || PathPrefix(`/app/lapi/`) || PathPrefix(`/kyc/lapi/`))"
+      - "traefik.http.routers.green-lapi.entrypoints=internal"
+      - "traefik.http.routers.green-lapi.middlewares=api-limit"
+      - "traefik.http.routers.green-lapi.service=nginx"
+
       # Service definition
       - "traefik.http.services.nginx.loadbalancer.server.port=80"
 


### PR DESCRIPTION
 This PR adds a local only /lapi access path for the app, kyc and proxy services. Requests sent to http://localhost:8443 can now be routed to the relevant container via Traefik’s internal entrypoint, while the public blue/green routes remain unchanged.

### Changes:
- Add localhost Traefik routing for /app/lapi/, /kyc/lapi/ and /proxy/lapi/ on the internal entrypoint
- Keep the existing public /api and /sapi routing intact
- Preserve the current reverse proxy behavior
