### PR TITLE
fix(ui): unify password-flow error message + translate UBL upload modal (#265)

### DIFF
--- a/app/ui/src/account/change-password-modal.html
+++ b/app/ui/src/account/change-password-modal.html
@@ -10,7 +10,7 @@
         <div class="modal-body">
             <form class="auth-form">
                 <choose-password component.ref="choosePassword" password.two-way="password" confirm-password.two-way="confirmPassword"></choose-password>
-                <p if.bind="error" class="form-error" t="forgot.reset-failed">Change password failed</p>
+                <p if.bind="error" class="form-error" t="account.change-password-failed">Change password failed</p>
             </form>
         </div>
         <footer class="modal-footer">

--- a/app/ui/src/app/locale/translation_de.json
+++ b/app/ui/src/app/locale/translation_de.json
@@ -174,6 +174,7 @@
   "common": {
     "apply": "Anwenden",
     "cancel": "Abbrechen",
+            "retry": "Erneut versuchen",
     "clear": "Leeren",
     "close": "Schließen",
     "confirm": "Bestätigen",
@@ -476,6 +477,8 @@
     },
     "title": "Rechnungen",
     "validationModal": {
+            "upload-title": "UBL hochladen",
+            "drop-ubl": "UBL hier ablegen",
       "error-count": "Anzahl der Fehler",
       "title": "Validierung"
     },

--- a/app/ui/src/app/locale/translation_de.json
+++ b/app/ui/src/app/locale/translation_de.json
@@ -1,5 +1,6 @@
 {
   "account": {
+        "change-password-failed": "Passwort \u00e4ndern fehlgeschlagen",
     "account-name": "Kontoname",
     "activate-on-peppol": "Auf Peppol aktivieren",
     "add-attachment-to-notification": "Anhang zur Benachrichtigung hinzufügen",

--- a/app/ui/src/app/locale/translation_en.json
+++ b/app/ui/src/app/locale/translation_en.json
@@ -1,5 +1,6 @@
 {
   "account": {
+        "change-password-failed": "Change password failed",
     "account-name": "Account Name",
     "activate-on-peppol": "Activate On Peppol",
     "add-attachment-to-notification": "Add attachment to notification",

--- a/app/ui/src/app/locale/translation_en.json
+++ b/app/ui/src/app/locale/translation_en.json
@@ -174,6 +174,7 @@
   "common": {
     "apply": "Apply",
     "cancel": "Cancel",
+            "retry": "Retry",
     "clear": "Clear",
     "close": "Close",
     "confirm": "Confirm",
@@ -476,6 +477,8 @@
     },
     "title": "Invoices",
     "validationModal": {
+            "upload-title": "Upload UBL",
+            "drop-ubl": "Drop UBL here",
       "error-count": "Error count",
       "title": "Validation"
     },

--- a/app/ui/src/app/locale/translation_fr.json
+++ b/app/ui/src/app/locale/translation_fr.json
@@ -1,5 +1,6 @@
 {
   "account": {
+        "change-password-failed": "\u00c9chec du changement de mot de passe",
     "account-name": "Nom du compte",
     "activate-on-peppol": "Activer sur Peppol",
     "add-attachment-to-notification": "Ajouter une pièce jointe à la notification",

--- a/app/ui/src/app/locale/translation_fr.json
+++ b/app/ui/src/app/locale/translation_fr.json
@@ -173,6 +173,7 @@
   "common": {
     "apply": "Appliquer",
     "cancel": "Annuler",
+            "retry": "R\u00e9essayer",
     "clear": "Effacer",
     "close": "Fermer",
     "confirm": "Confirmer",
@@ -473,6 +474,8 @@
     },
     "title": "Factures",
     "validationModal": {
+            "upload-title": "T\u00e9l\u00e9verser UBL",
+            "drop-ubl": "D\u00e9posez le fichier UBL ici",
       "error-count": "Nombre d'erreurs",
       "title": "Validation"
     },

--- a/app/ui/src/app/locale/translation_nl.json
+++ b/app/ui/src/app/locale/translation_nl.json
@@ -173,6 +173,7 @@
   "common": {
     "apply": "Toepassen",
     "cancel": "Annuleren",
+            "retry": "Opnieuw",
     "clear": "Wissen",
     "close": "Sluiten",
     "confirm": "Bevestigen",
@@ -473,6 +474,8 @@
     },
     "title": "Facturen",
     "validationModal": {
+            "upload-title": "UBL uploaden",
+            "drop-ubl": "Sleep UBL hierheen",
       "error-count": "Aantal fouten",
       "title": "Validatie"
     },

--- a/app/ui/src/app/locale/translation_nl.json
+++ b/app/ui/src/app/locale/translation_nl.json
@@ -1,5 +1,6 @@
 {
   "account": {
+        "change-password-failed": "Wijzigen van wachtwoord mislukt",
     "account-name": "Accountnaam",
     "activate-on-peppol": "Activeren op Peppol",
     "add-attachment-to-notification": "Bijlage toevoegen aan de melding",

--- a/app/ui/src/invoice/overview/components/upload-ubl-modal.html
+++ b/app/ui/src/invoice/overview/components/upload-ubl-modal.html
@@ -2,7 +2,7 @@
     <div class="modal-backdrop"></div>
     <div class="modal-card" style.bind="validationResult ? 'width: 1000px' : ''">
         <header class="modal-header">
-            <h2>Upload UBL</h2>
+            <h2 t="invoice.validationModal.upload-title">Upload UBL</h2>
             <button class="icon-btn" click.trigger="closeModal()" aria-label="Close dialog" t="[aria-label]common.close" title="Close" t="[title]common.close">×</button>
         </header>
         <div class="modal-body">
@@ -14,7 +14,7 @@
                  drop.trigger="dragDrop($event, 'file')"
                  if.bind="!validationResult"
             >
-                <p>Drop UBL</p>
+                <p t="invoice.validationModal.drop-ubl">Drop UBL</p>
                 <svg width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-up-icon lucide-file-up"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M12 12v6"/><path d="m15 15-3-3-3 3"/></svg>
             </div>
 
@@ -28,7 +28,7 @@
             </template>
         </div>
         <footer class="modal-footer" if.bind="validationResult">
-            <button type="button" class="btn" click.trigger="retry()" title="Cancel" t="[title]common.cancel" t="common.cancel">Retry</button>
+            <button type="button" class="btn" click.trigger="retry()" title="Cancel" t="[title]common.cancel" t="common.retry">Retry</button>
         </footer>
     </div>
 </div>


### PR DESCRIPTION
Fixes #265 (partial — addresses the translation/i18n items)

## Changes

### 1. Password flows use a dedicated error key
`account/change-password-modal.html` reused the `forgot.reset-failed` key ("Reset password failed") for the change-password flow, showing the wrong message. Now uses a new key `account.change-password-failed`, added to all 4 locales (en/nl/fr/de).

### 2. UBL upload modal is now translatable
`upload-ubl-modal.html` contained hardcoded strings:
- `<h2>Upload UBL</h2>` → `invoice.validationModal.upload-title`
- `<p>Drop UBL</p>` → `invoice.validationModal.drop-ubl`
- "Retry" button was using `common.cancel` → new `common.retry`

All new keys translated in en, nl, fr, de.

## Scope
Only the files listed above were touched. No logic changes.

## Verification
- `vitest run`: 57/57 tests pass; the one failing suite (`smart-truncate.spec.ts`, missing source file) fails identically on `main` — pre-existing, unrelated.
- `npm run lint:js`: all reported errors are pre-existing on `main`; no new errors introduced.
- Verified keys resolve in the running Vite dev server (`translation_en.json` served with new keys present).