### PR TITLE
fix(ui): actionable Web eID error messages instead of raw library strings (#199)

### DIFF
--- a/app/ui/.gitignore
+++ b/app/ui/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+playwright-report/

--- a/app/ui/e2e/webeid-error.spec.ts
+++ b/app/ui/e2e/webeid-error.spec.ts
@@ -1,0 +1,41 @@
+// E2E regression test for issue #199:
+// when the Web eID native app / extension is unavailable, clicking
+// "Check Web eID" on the onboarding page must show an actionable localized
+// message instead of the raw library string
+// "Web-eID extension is not available".
+//
+// The eID hardware itself is never involved on this error path — it fails at
+// library startup — so we simulate an environment without Web eID by removing
+// the browser integration points the library relies on.
+import {test, expect, type Page} from "@playwright/test";
+
+const RAW_LIBRARY_MESSAGE = "Web-eID extension is not available";
+// English text of i18n key `webeid.native-unavailable` (Chromium default UA).
+const ACTIONABLE_MESSAGE = "Web eID application not found";
+
+async function stubNoWebeid(page: Page) {
+    await page.addInitScript(() => {
+        // The library probes navigator/window for the extension injection
+        // points; remove them so every lookup fails as if nothing is installed.
+        const nav = navigator as any;
+        delete nav.WebEID;
+        (window as any).WebEID = undefined;
+    });
+}
+
+test("onboarding shows actionable message when Web eID is unavailable", async ({page}) => {
+    await stubNoWebeid(page);
+    await page.goto("/onboarding");
+
+    // Click the real user entry point that triggers the web-eid library call.
+    await page.getByRole("button", {name: /Check Web eID/i}).click();
+
+    const alert = page.locator("#alert");
+    await expect(alert).toBeVisible();
+    const text = await alert.textContent();
+
+    // The raw, misleading library string must NOT be shown (#199)…
+    expect(text).not.toContain(RAW_LIBRARY_MESSAGE);
+    // …and the actionable guidance must appear instead.
+    expect(text).toContain(ACTIONABLE_MESSAGE);
+});

--- a/app/ui/package-lock.json
+++ b/app/ui/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@aurelia/testing": "^2.0.0-rc.1",
         "@aurelia/vite-plugin": "^2.0.0-rc.1",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^22.10.2",
         "eslint": "^9.17.0",
         "globals": "^15.14.0",
@@ -1859,6 +1860,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/plugin-inject": {
@@ -5811,6 +5828,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@aurelia/testing": "^2.0.0-rc.1",
     "@aurelia/vite-plugin": "^2.0.0-rc.1",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^22.10.2",
     "eslint": "^9.17.0",
     "globals": "^15.14.0",

--- a/app/ui/playwright.config.ts
+++ b/app/ui/playwright.config.ts
@@ -1,0 +1,16 @@
+import {defineConfig} from "@playwright/test";
+
+export default defineConfig({
+    testDir: "./e2e",
+    timeout: 30_000,
+    use: {
+        baseURL: "http://localhost:3010",
+        headless: true,
+    },
+    webServer: {
+        command: "npx vite --port 3010 --strictPort",
+        url: "http://localhost:3010",
+        reuseExistingServer: true,
+        timeout: 60_000,
+    },
+});

--- a/app/ui/src/app/locale/translation_de.json
+++ b/app/ui/src/app/locale/translation_de.json
@@ -1,4 +1,9 @@
 {
+    "webeid": {
+        "native-unavailable": "Web-eID-Anwendung nicht gefunden. Installieren oder starten Sie die Web-eID-Anwendung und starten Sie Ihren Browser neu.",
+        "extension-unavailable": "Web-eID-Browsererweiterung nicht verfügbar. Installieren und aktivieren Sie die Web-eID-Erweiterung in Ihrem Browser.",
+        "version-mismatch": "Die Web-eID-Software ist veraltet. Bitte aktualisieren Sie sowohl die Web-eID-Anwendung als auch die Browsererweiterung."
+    },
   "account": {
     "account-name": "Kontoname",
     "activate-on-peppol": "Auf Peppol aktivieren",

--- a/app/ui/src/app/locale/translation_en.json
+++ b/app/ui/src/app/locale/translation_en.json
@@ -1,4 +1,9 @@
 {
+    "webeid": {
+        "native-unavailable": "Web eID application not found. Install or start the Web eID application, then restart your browser.",
+        "extension-unavailable": "Web eID browser extension not available. Install and enable the Web eID extension in your browser.",
+        "version-mismatch": "Web eID software is outdated. Please update both the Web eID application and browser extension."
+    },
   "account": {
     "account-name": "Account Name",
     "activate-on-peppol": "Activate On Peppol",

--- a/app/ui/src/app/locale/translation_fr.json
+++ b/app/ui/src/app/locale/translation_fr.json
@@ -1,4 +1,9 @@
 {
+    "webeid": {
+        "native-unavailable": "Application Web eID introuvable. Installez ou lancez l’application Web eID, puis redémarrez votre navigateur.",
+        "extension-unavailable": "Extension de navigateur Web eID indisponible. Installez et activez l’extension Web eID dans votre navigateur.",
+        "version-mismatch": "Le logiciel Web eID est obsolète. Veuillez mettre à jour l’application Web eID et l’extension de navigateur."
+    },
   "account": {
     "account-name": "Nom du compte",
     "activate-on-peppol": "Activer sur Peppol",

--- a/app/ui/src/app/locale/translation_nl.json
+++ b/app/ui/src/app/locale/translation_nl.json
@@ -1,4 +1,9 @@
 {
+    "webeid": {
+        "native-unavailable": "Web eID-applicatie niet gevonden. Installeer of start de Web eID-applicatie en herstart uw browser.",
+        "extension-unavailable": "Web eID-browserextensie niet beschikbaar. Installeer en activeer de Web eID-extensie in uw browser.",
+        "version-mismatch": "Web eID-software is verouderd. Werk zowel de Web eID-applicatie als de browserextensie bij."
+    },
   "account": {
     "account-name": "Accountnaam",
     "activate-on-peppol": "Activeren op Peppol",

--- a/app/ui/src/app/util/webeid-error-handler.ts
+++ b/app/ui/src/app/util/webeid-error-handler.ts
@@ -1,0 +1,31 @@
+// Maps web-eID library errors to localized, actionable messages.
+// The raw library strings (e.g. "Web-eID extension is not available") are
+// misleading in Chromium-based browsers, where a missing native app surfaces
+// as an extension error. See issue #199.
+import ExtensionUnavailableError from "@web-eid/web-eid-library/errors/ExtensionUnavailableError";
+import NativeUnavailableError from "@web-eid/web-eid-library/errors/NativeUnavailableError";
+import VersionMismatchError from "@web-eid/web-eid-library/errors/VersionMismatchError";
+import {I18N} from "@aurelia/i18n";
+
+export function isChromiumBrowser(ua: string = navigator.userAgent): boolean {
+  return /Chrome|Chromium|Edg|Opera/.test(ua) && !/Firefox/.test(ua);
+}
+
+export function toLocalizedWebEidErrorMessage(error: unknown, i18n: I18N, ua?: string): string {
+  if (error instanceof NativeUnavailableError) {
+    return i18n.tr("webeid.native-unavailable");
+  }
+  if (error instanceof ExtensionUnavailableError) {
+    // Firefox needs the user-installed Web eID extension; Chromium-based
+    // browsers connect to the native app directly, so the fix there is
+    // installing/starting the native application.
+    if (isChromiumBrowser(ua)) {
+      return i18n.tr("webeid.native-unavailable");
+    }
+    return i18n.tr("webeid.extension-unavailable");
+  }
+  if (error instanceof VersionMismatchError) {
+    return i18n.tr("webeid.version-mismatch");
+  }
+  return undefined;
+}

--- a/app/ui/src/registration/email-confirmation.ts
+++ b/app/ui/src/registration/email-confirmation.ts
@@ -16,6 +16,7 @@ import {LibrarySignResponse} from "@web-eid/web-eid-library/models/message/Libra
 import {I18N} from "@aurelia/i18n";
 import {ChoosePassword} from "../components/choose-password/choose-password";
 import {clearTokenFromUrl} from "../services/util/url";
+import {toLocalizedWebEidErrorMessage} from "../app/util/webeid-error-handler";
 
 export class EmailConfirmation {
     readonly ea: IEventAggregator = resolve(IEventAggregator);
@@ -121,8 +122,13 @@ export class EmailConfirmation {
                 } catch {
                     text = `${error.status} ${error.statusText}`;
                 }
-            } else if (error && typeof error === "object" && "message" in error) {
-                text = String((error as any).message);
+            } else {
+                const webeidText = toLocalizedWebEidErrorMessage(error, this.i18n);
+                if (webeidText) {
+                    text = webeidText;
+                } else if (error && typeof error === "object" && "message" in error) {
+                    text = String((error as any).message);
+                }
             }
             this.ea.publish('alert', { alertType: AlertType.Danger, text });
             this.confirmInProgress = false;
@@ -197,8 +203,13 @@ export class EmailConfirmation {
                 } catch {
                     text = `${error.status} ${error.statusText}`;
                 }
-            } else if (error && typeof error === "object" && "message" in error) {
-                text = String((error as any).message);
+            } else {
+                const webeidText = toLocalizedWebEidErrorMessage(error, this.i18n);
+                if (webeidText) {
+                    text = webeidText;
+                } else if (error && typeof error === "object" && "message" in error) {
+                    text = String((error as any).message);
+                }
             }
             this.ea.publish('alert', { alertType: AlertType.Danger, text });
             this.confirmedDirector = undefined;

--- a/app/ui/src/registration/onboarding.ts
+++ b/app/ui/src/registration/onboarding.ts
@@ -1,9 +1,13 @@
 import {resolve} from "@aurelia/kernel";
 import * as webeid from '@web-eid/web-eid-library/web-eid';
 import {IEventAggregator} from "aurelia";
+import {AlertType} from "../components/alert/alert";
+import {toLocalizedWebEidErrorMessage} from "../app/util/webeid-error-handler";
+import {I18N} from "@aurelia/i18n";
 
 export class Onboarding {
     readonly ea: IEventAggregator = resolve(IEventAggregator);
+    private readonly i18n = resolve(I18N);
     private certificate = null;
     private signatureAlgorithm = null;
 
@@ -25,8 +29,13 @@ export class Onboarding {
                     } catch {
                         text = `${error.status} ${error.statusText}`;
                     }
-                } else if (error && typeof error === "object" && "message" in error) {
-                    text = String((error as any).message);
+                } else {
+                    const webeidText = toLocalizedWebEidErrorMessage(error, this.i18n);
+                    if (webeidText) {
+                        text = webeidText;
+                    } else if (error && typeof error === "object" && "message" in error) {
+                        text = String((error as any).message);
+                    }
                 }
                 this.ea.publish('alert', { alertType: AlertType.Danger, text });
             }

--- a/app/ui/test/app/util/webeid-error-handler.spec.ts
+++ b/app/ui/test/app/util/webeid-error-handler.spec.ts
@@ -1,0 +1,58 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from "vitest";
+import ExtensionUnavailableError from "@web-eid/web-eid-library/errors/ExtensionUnavailableError";
+import NativeUnavailableError from "@web-eid/web-eid-library/errors/NativeUnavailableError";
+import VersionMismatchError from "@web-eid/web-eid-library/errors/VersionMismatchError";
+import {toLocalizedWebEidErrorMessage, isChromiumBrowser} from "../../../src/app/util/webeid-error-handler";
+
+const i18nMock = {tr: (key: string) => `i18n:${key}`} as any;
+
+const CHROMIUM_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const FIREFOX_UA = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
+
+describe("isChromiumBrowser", () => {
+    it("detects Chromium browsers", () => {
+        expect(isChromiumBrowser(CHROMIUM_UA)).toBe(true);
+        expect(isChromiumBrowser(FIREFOX_UA)).toBe(false);
+    });
+});
+
+describe("toLocalizedWebEidErrorMessage", () => {
+    let uaSpy;
+
+    function setUA(ua: string) {
+        uaSpy = vi.spyOn(navigator, "userAgent", "get").mockReturnValue(ua);
+    }
+
+    afterEach(() => uaSpy?.mockRestore());
+
+    it("maps NativeUnavailableError to the native-app message", () => {
+        setUA(CHROMIUM_UA);
+        const text = toLocalizedWebEidErrorMessage(new NativeUnavailableError(), i18nMock);
+        expect(text).toBe("i18n:webeid.native-unavailable");
+    });
+
+    it("maps ExtensionUnavailableError on Chromium to the native-app message", () => {
+        // Regression for #199: in Chromium a missing native app surfaces as
+        // an extension error; the user should be told to install/start the app.
+        setUA(CHROMIUM_UA);
+        const text = toLocalizedWebEidErrorMessage(new ExtensionUnavailableError(), i18nMock);
+        expect(text).toBe("i18n:webeid.native-unavailable");
+    });
+
+    it("maps ExtensionUnavailableError on Firefox to the extension message", () => {
+        setUA(FIREFOX_UA);
+        const text = toLocalizedWebEidErrorMessage(new ExtensionUnavailableError(), i18nMock);
+        expect(text).toBe("i18n:webeid.extension-unavailable");
+    });
+
+    it("maps VersionMismatchError to the update message", () => {
+        setUA(CHROMIUM_UA);
+        const text = toLocalizedWebEidErrorMessage(new VersionMismatchError(undefined, {nativeApp: "2.8.0", extension: "2.8.0", library: "2.8.0"}, {extension: true, nativeApp: true}), i18nMock);
+        expect(text).toBe("i18n:webeid.version-mismatch");
+    });
+
+    it("returns undefined for unrelated errors so callers keep their fallback", () => {
+        const text = toLocalizedWebEidErrorMessage(new Error("something else"), i18nMock);
+        expect(text).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixes #199

## Root cause

The message *"Web-eID extension is not available"* comes from the third-party web-eID library (`ExtensionUnavailableError`), and the UI displayed `error.message` verbatim. Two problems:

1. **Misleading on Chromium-based browsers**: there, the browser talks to the native app directly; when the native app isn't installed/running, the failure surfaces as an *extension* error even though no extension is involved. (In my case the Web eID desktop application simply wasn't installed.)
2. **Not actionable**: the user is told about an "extension" with no guidance on what to actually install or start.

## Fix

- New helper `app/util/webeid-error-handler.ts` maps typed library errors to localized, actionable messages:
  - `NativeUnavailableError`, or `ExtensionUnavailableError` on Chromium → *"Web eID application not found. Install or start the Web eID application, then restart your browser."*
  - `ExtensionUnavailableError` on Firefox → extension-specific guidance
  - `VersionMismatchError` → update guidance
  - anything else → unchanged fallback behavior
- Wired into both catch sites: `registration/onboarding.ts` and `registration/email-confirmation.ts`
- New `webeid.*` i18n keys in en/nl/fr/de

## Screenshot (after fix — Chromium, no Web eID installed)

![Web eID actionable alert](https://github.com/Aldo-f/letspeppol/releases/download/webeid-fix-shot/webeid-alert2.png)

## Verification

- **Unit tests** (new `test/app/util/webeid-error-handler.spec.ts`, 6 tests): error-type × browser-UA matrix, fallback passthrough — all pass
- **Playwright e2e** (new, separate commit): stubs an environment without Web eID, clicks the real "Check Web eID" button on `/onboarding`, and asserts the actionable message appears and the raw library string does **not**. Verified **fails on `main`**, **passes on this branch**.
- Full vitest suite: 63/63 tests pass (the `smart-truncate.spec.ts` suite failure is pre-existing on `main` — missing source file)
- `npm run lint:js`: no new errors vs main baseline
- Runtime evidence: Vite dev server + real browser click-through, screenshot above

## Commits

1. `9712ec9` — the fix (helper + wire-up + i18n)
2. `057a285` — Playwright scaffolding + e2e regression test (separate, per review preference; happy to move to CI or drop if the maintainers prefer vitest-only)