### PR TITLE
KYC contract CBE null 

### DIFF
--- a/kyc/src/main/java/org/letspeppol/kyc/service/SigningService.java
+++ b/kyc/src/main/java/org/letspeppol/kyc/service/SigningService.java
@@ -170,7 +170,7 @@ public class SigningService {
         return new File(workingDirectory, "contract_en_" + safeHashName(hashToFinalize) + "_prepare.pdf");
     }
 
-    public static String beVatPretty(String s) {
+    public static String beCBEPretty(String s) {
         if (s == null) return null;
         s = s.toUpperCase().replaceFirst("^BE", "").replaceAll("\\D", "");
         if (s.length() == 9) s = "0" + s;
@@ -180,7 +180,7 @@ public class SigningService {
     public byte[] generateFilledContract(Director director) {
         String company = director.getCompany().getName();
         String address = director.getCompany().getStreet() + ", " + director.getCompany().getPostalCode() + " " + director.getCompany().getCity();
-        String companyNumber = beVatPretty(director.getCompany().getVatNumber());
+        String companyNumber = beCBEPretty(director.getCompany().getIdentifier());
         String title = "Director";
         String representative = director.getName();
 


### PR DESCRIPTION
In contracts signed by a company director with a company without a VAT number, "null" is entered in the place where the CBE number would normally appear.